### PR TITLE
feat: lift to expressions, vacuous and random_search tactics

### DIFF
--- a/Plausible/MetaTestable.lean
+++ b/Plausible/MetaTestable.lean
@@ -77,6 +77,15 @@ def andProp? (e: Expr) : MetaM (Option Expr × Option Expr) := do
   else
     return (none, none)
 
+def notProp? (e: Expr) : MetaM (Option Expr) := do
+  let prop := mkSort levelZero
+  let α ← mkFreshExprMVar prop
+  let e' ← mkAppM ``Not #[α]
+  if ← isDefEq e' e then
+    return (← Lean.getExprMVarAssignment? α.mvarId!)
+  else
+    return none
+
 def forallProp? (e: Expr) : MetaM (Option Expr × Option Expr) := do
   let u ← mkFreshLevelMVar
   let α ← mkFreshExprMVar (mkSort u)
@@ -696,17 +705,7 @@ def disproveM? (cfg : Configuration) (tgt: Expr) : MetaM <| Option Expr := do
   let code ← unsafe evalExpr (Expr → MetaM (Option Expr)) expectedType e
   code tgt
 
+-- Negate
 
--- #eval MetaTestable.check (∀ (x y z a : Nat) (h1 : 3 < x) (h2 : 3 < y), x - y = y - x)
---   Configuration.verbose
--- #eval MetaTestable.check (∀ x : Nat, ∀ y : Nat, x + y = y + x) Configuration.verbose
--- #eval MetaTestable.check (∀ (x : (Nat × Nat)), x.fst - x.snd - 10 = x.snd - x.fst - 10)
---   Configuration.verbose
--- #eval MetaTestable.check (∀ (x : Nat) (h : 10 < x), 5 < x) Configuration.verbose
-
-macro tk:"#test " e:term : command => `(command| #eval%$tk MetaTestable.check $e)
-
--- #test ∀ (x : Nat) (h : 5 < x), 10 < x
--- #test ∀ (x : Nat) (h : 10 < x), 5 < x
 
 end Plausible

--- a/Plausible/MetaTestable.lean
+++ b/Plausible/MetaTestable.lean
@@ -1,0 +1,586 @@
+/-
+Copyright (c) 2022 Henrik Böving. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Henrik Böving, Simon Hudon
+-/
+import Lean.Elab.Tactic.Config
+import Plausible.Sampleable
+import Plausible.Testable
+open Lean
+
+/-!
+# `MetaTestable` Class
+
+MetaTestable propositions have a procedure that can generate counter-examples
+together with a proof that they invalidate the proposition.
+
+This is a port of the Haskell QuickCheck library.
+
+## Creating Customized Instances
+
+The type classes `MetaTestable`, `SampleableExt` and `Shrinkable` are the
+means by which `Plausible` creates samples and tests them. For instance,
+the proposition `∀ i j : Nat, i ≤ j` has a `MetaTestable` instance because `Nat`
+is sampleable and `i ≤ j` is decidable. Once `Plausible` finds the `MetaTestable`
+instance, it can start using the instance to repeatedly creating samples
+and checking whether they satisfy the property. Once it has found a
+counter-example it will then use a `Shrinkable` instance to reduce the
+example. This allows the user to create new instances and apply
+`Plausible` to new situations.
+
+### What do I do if I'm testing a property about my newly defined type?
+
+Let us consider a type made for a new formalization:
+
+```lean
+structure MyType where
+  x : Nat
+  y : Nat
+  h : x ≤ y
+  deriving Repr
+```
+
+How do we test a property about `MyType`? For instance, let us consider
+`MetaTestable.check <| ∀ a b : MyType, a.y ≤ b.x → a.x ≤ b.y`. Writing this
+property as is will give us an error because we do not have an instance
+of `Shrinkable MyType` and `SampleableExt MyType`. We can define one as follows:
+
+```lean
+instance : Shrinkable MyType where
+  shrink := fun ⟨x, y, _⟩ =>
+    let proxy := Shrinkable.shrink (x, y - x)
+    proxy.map (fun (fst, snd) => ⟨fst, fst + snd, by omega⟩)
+
+instance : SampleableExt MyType :=
+  SampleableExt.mkSelfContained do
+    let x ← SampleableExt.interpSample Nat
+    let xyDiff ← SampleableExt.interpSample Nat
+    return ⟨x, x + xyDiff, by omega⟩
+```
+
+Again, we take advantage of the fact that other types have useful
+`Shrinkable` implementations, in this case `Prod`.
+
+## Main definitions
+
+* `MetaTestable` class
+* `MetaTestable.check`: a way to test a proposition using random examples
+
+## References
+
+* https://hackage.haskell.org/package/QuickCheck
+
+-/
+
+namespace Plausible
+
+section Matching
+open Lean Meta
+/-!
+# Matching propositions of specific forms
+-/
+def existsProp? (e: Expr) : MetaM (Option Expr × Option Expr) := do
+  let u ← mkFreshLevelMVar
+  let α ← mkFreshExprMVar (mkSort u)
+  let prop := mkSort levelZero
+  let fmly ← mkArrow α prop
+  let mvar ← mkFreshExprMVar (some fmly)
+  let e' ←  mkAppM ``Exists #[mvar]
+  if ← isDefEq e' e then
+    return (← Lean.getExprMVarAssignment? mvar.mvarId!, ← Lean.getExprMVarAssignment? α.mvarId!)
+  else
+    return (none, none)
+
+def orProp? (e: Expr) : MetaM (Option Expr × Option Expr) := do
+  let prop := mkSort levelZero
+  let α ← mkFreshExprMVar prop
+  let β ← mkFreshExprMVar prop
+  let e' ← mkAppM ``Or #[α, β]
+  if ← isDefEq e' e then
+    return (← Lean.getExprMVarAssignment? α.mvarId!, ← Lean.getExprMVarAssignment? β.mvarId!)
+  else
+    return (none, none)
+
+def andProp? (e: Expr) : MetaM (Option Expr × Option Expr) := do
+  let prop := mkSort levelZero
+  let α ← mkFreshExprMVar prop
+  let β ← mkFreshExprMVar prop
+  let e' ← mkAppM ``And #[α, β]
+  if ← isDefEq e' e then
+    return (← Lean.getExprMVarAssignment? α.mvarId!, ← Lean.getExprMVarAssignment? β.mvarId!)
+  else
+    return (none, none)
+
+#check mkFreshLevelMVar
+
+def forallProp? (e: Expr) : MetaM (Option Expr × Option Expr) := do
+  let u ← mkFreshLevelMVar
+  let α ← mkFreshExprMVar (mkSort u)
+  let prop := mkSort levelZero
+  let fmly ← mkArrow α prop
+  let mvar ← mkFreshExprMVar (some fmly)
+  let e' ← withLocalDeclD `x α fun x => do
+    let y ← mkAppM' mvar #[x]
+    mkForallFVars #[x] y
+  if ← isDefEq e' e then
+    return (← Lean.getExprMVarAssignment? mvar.mvarId!, ← Lean.getExprMVarAssignment? α.mvarId!)
+  else
+    return (none, none)
+
+def impProp? (e: Expr) : MetaM (Option Expr × Option Expr) := do
+  let prop := mkSort levelZero
+  let α ← mkFreshExprMVar prop
+  let β ← mkFreshExprMVar prop
+  let e' ←  mkArrow α β
+  if ← isDefEq e' e then
+    return (← Lean.getExprMVarAssignment? α.mvarId!, ← Lean.getExprMVarAssignment? β.mvarId!)
+  else
+    return (none, none)
+
+def eqlProp? (e: Expr): MetaM (Option (Expr × Expr × Expr)) := do
+  let level ←  mkFreshLevelMVar
+  let u := mkSort level
+  let α ← mkFreshExprMVar u
+  let a ← mkFreshExprMVar α
+  let b ← mkFreshExprMVar α
+  let e' ← mkAppM ``Eq #[a, b]
+  if ← isDefEq e' e then
+    let α? ← Lean.getExprMVarAssignment? α.mvarId!
+    let a? ← Lean.getExprMVarAssignment? a.mvarId!
+    let b? ← Lean.getExprMVarAssignment? b.mvarId!
+    let triple : Option (Expr × Expr × Expr) := do
+      let α ← α?
+      let a ← a?
+      let b ← b?
+      return (α, a, b)
+    return triple
+  else
+    return none
+
+def equality? (e: Expr): MetaM (Option (Expr × Expr × Expr)) := do
+  let level ←  mkFreshLevelMVar
+  let u := mkSort level
+  let α ← mkFreshExprMVar u
+  let a ← mkFreshExprMVar α
+  let b ← mkFreshExprMVar α
+  let e' ← mkAppM ``Eq #[a, b]
+  let c ← mkFreshExprMVar e'
+  if ← isDefEq c e then
+    let α? ← Lean.getExprMVarAssignment? α.mvarId!
+    let a? ← Lean.getExprMVarAssignment? a.mvarId!
+    let b? ← Lean.getExprMVarAssignment? b.mvarId!
+    let triple : Option (Expr × Expr × Expr) := do
+      let α ← α?
+      let a ← a?
+      let b ← b?
+      return (α, a, b)
+    return triple
+  else
+    return none
+end Matching
+
+
+/-- Result of trying to disprove `p` -/
+inductive MetaTestResult (p : Prop) where
+  /--
+  Succeed when we find another example satisfying `p`.
+  In `success h`, `h` is an optional proof of the proposition.
+  Without the proof, all we know is that we found one example
+  where `p` holds. With a proof, the one test was sufficient to
+  prove that `p` holds and we do not need to keep finding examples.
+  -/
+  | success : Unit ⊕' p → MetaTestResult p
+  /--
+  Give up when a well-formed example cannot be generated.
+  `gaveUp n` tells us that `n` invalid examples were tried.
+  -/
+  | gaveUp : Nat → MetaTestResult p
+  /--
+  There was a mismatch between `p` and the expression representing `p`
+  -/
+  | mismatch : String → MetaTestResult p
+  /--
+  A counter-example to `p`; the strings specify values for the relevant variables.
+  `failure h vs n` also carries a proof that `p` does not hold. This way, we can
+  guarantee that there will be no false positive. The last component, `n`,
+  is the number of times that the counter-example was shrunk.
+  -/
+  | failure : ¬ p → Expr → List String → Nat → MetaTestResult p
+  deriving Inhabited
+
+
+/-- `MetaTestable p` uses random examples to try to disprove `p`. -/
+class MetaTestable (p : Prop) where
+  run (cfg : Configuration) (minimize : Bool) (propExpr : Expr) :  Gen (MetaTestResult p)
+
+
+namespace MetaTestResult
+
+def toString : MetaTestResult p → String
+  | success (PSum.inl _) => "success (no proof)"
+  | success (PSum.inr _) => "success (proof)"
+  | gaveUp n => s!"gave {n} times"
+  | failure _ _ counters _ => s!"failed {counters}"
+  | mismatch s => s!"Mismatch: {s}"
+
+instance : ToString (MetaTestResult p) := ⟨toString⟩
+
+/-- Applicative combinator proof carrying test results. -/
+def combine {p q : Prop} : Unit ⊕' (p → q) → Unit ⊕' p → Unit ⊕' q
+  | PSum.inr f, PSum.inr proof => PSum.inr <| f proof
+  | _, _ => PSum.inl ()
+
+/-- Combine the test result for properties `p` and `q` to create a test for their conjunction. -/
+def and : MetaTestResult p → MetaTestResult q → MetaTestResult (p ∧ q)
+  | failure h pf xs n, _ =>
+    failure (fun h2 => h h2.left) pf xs n
+  | _, failure h pf xs n => failure (fun h2 => h h2.right) pf  xs n
+  | success h1, success h2 => success <| combine (combine (PSum.inr And.intro) h1) h2
+  | gaveUp n, gaveUp m => gaveUp <| n + m
+  | gaveUp n, _ => gaveUp n
+  | _, gaveUp n => gaveUp n
+  | mismatch s, _ => mismatch s
+  | _, mismatch s => mismatch s
+
+/-- Combine the test result for properties `p` and `q` to create a test for their disjunction. -/
+def or : MetaTestResult p → MetaTestResult q → MetaTestResult (p ∨ q)
+  | failure h1 pf1 xs n, failure h2 pf2 ys m =>
+    let h3 := fun h =>
+      match h with
+      | Or.inl h3 => h1 h3
+      | Or.inr h3 => h2 h3
+    failure h3 pf1 (xs ++ ys) (n + m)
+  | success h, _ => success <| combine (PSum.inr Or.inl) h
+  | _, success h => success <| combine (PSum.inr Or.inr) h
+  | gaveUp n, gaveUp m => gaveUp <| n + m
+  | gaveUp n, _ => gaveUp n
+  | _, gaveUp n => gaveUp n
+  | mismatch s, _ => mismatch s
+  | _, mismatch s => mismatch s
+
+/-- If `q → p`, then `¬ p → ¬ q` which means that testing `p` can allow us
+to find counter-examples to `q`. -/
+def imp (h : q → p) (r : MetaTestResult p)
+    (p : Unit ⊕' (p → q) := PSum.inl ()) : MetaTestResult q :=
+  match r with
+  | failure h2 pf xs n => failure (mt h h2) pf xs n
+  | success h2 => success <| combine p h2
+  | gaveUp n => gaveUp n
+  | mismatch s => mismatch s
+
+/-- Test `q` by testing `p` and proving the equivalence between the two. -/
+def iff (h : q ↔ p) (r : MetaTestResult p) : MetaTestResult q :=
+  imp h.mp r (PSum.inr h.mpr)
+
+/-- When we assign a value to a universally quantified variable,
+we record that value using this function so that our counter-examples
+can be informative. -/
+def addInfo (x : String) (h : q → p) (r : MetaTestResult p)
+    (p : Unit ⊕' (p → q) := PSum.inl ()) : MetaTestResult q :=
+  if let failure h2 pf xs n := r then
+    failure (mt h h2) pf (x :: xs) n
+  else
+    imp h r p
+
+/-- Add some formatting to the information recorded by `addInfo`. -/
+def addVarInfo {γ : Type _} [Repr γ] (var : String) (x : γ) (h : q → p) (r : MetaTestResult p)
+    (p : Unit ⊕' (p → q) := PSum.inl ()) : MetaTestResult q :=
+  addInfo s!"{var} := {repr x}" h r p
+
+def isFailure : MetaTestResult p → Bool
+  | failure .. => true
+  | _ => false
+
+end MetaTestResult
+
+
+namespace MetaTestable
+
+open MetaTestResult
+
+def runProp (p : Prop) [MetaTestable p] : Configuration → Bool → Expr → Gen (MetaTestResult p) := MetaTestable.run
+
+/-- A `dbgTrace` with special formatting -/
+def slimTrace {m : Type → Type _} [Pure m] (s : String) : m PUnit :=
+  dbgTrace s!"[Plausible: {s}]" (fun _ => pure ())
+
+instance andTestable [MetaTestable p] [MetaTestable q] : MetaTestable (p ∧ q) where
+  run := fun cfg min e => do
+  -- let pair ← andProp? e
+  -- match ← andProp? e with
+  -- | (some e₁, some e₂) => do
+    let xp ← runProp p cfg min e
+    let xq ← runProp q cfg min e
+    return and xp xq
+  -- | _ => return sorry
+
+instance orTestable [MetaTestable p] [MetaTestable q] : MetaTestable (p ∨ q) where
+  run := fun cfg min e => do
+    let xp ← runProp p cfg min e
+    -- As a little performance optimization we can just not run the second
+    -- test if the first succeeds
+    match xp with
+    | success (PSum.inl h) => return success (PSum.inl h)
+    | success (PSum.inr h) => return success (PSum.inr <| Or.inl h)
+    | _ =>
+      let xq ← runProp q cfg min e
+      return or xp xq
+
+instance iffTestable [MetaTestable ((p ∧ q) ∨ (¬ p ∧ ¬ q))] : MetaTestable (p ↔ q) where
+  run := fun cfg min e => do
+    let h ← runProp ((p ∧ q) ∨ (¬ p ∧ ¬ q)) cfg min e
+    have := by
+      constructor
+      · intro h
+        simp [h, Classical.em]
+      · intro h
+        rcases h with ⟨hleft, hright⟩ | ⟨hleft, hright⟩ <;> simp [hleft, hright]
+    return iff this h
+
+variable {var : String}
+
+instance decGuardTestable [PrintableProp p] [Decidable p] {β : p → Prop} [∀ h, MetaTestable (β h)] :
+    MetaTestable (NamedBinder var <| ∀ h, β h) where
+  run := fun cfg min e => do
+    if h : p then
+      let res := runProp (β h) cfg min e
+      let s := printProp p
+      (fun r => addInfo s!"guard: {s}" (· <| h) r (PSum.inr <| fun q _ => q)) <$> res
+    else if cfg.traceDiscarded || cfg.traceSuccesses then
+      let res := fun _ => return gaveUp 1
+      let s := printProp p
+      slimTrace s!"discard: Guard {s} does not hold"; res
+    else
+      return gaveUp 1
+
+instance forallTypesTestable {f : Type → Prop} [MetaTestable (f Int)] :
+    MetaTestable (NamedBinder var <| ∀ x, f x) where
+  run := fun cfg min e => do
+    let r ← runProp (f Int) cfg min e
+    return addVarInfo var "Int" (· <| Int) r
+
+-- TODO: only in mathlib: @[pp_with_univ]
+instance (priority := 100) forallTypesULiftTestable.{u}
+    {f : Type u → Prop} [MetaTestable (f (ULift.{u} Int))] :
+    MetaTestable (NamedBinder var <| ∀ x, f x) where
+  run cfg min e := do
+    let r ← runProp (f (ULift Int)) cfg min e
+    pure <| addVarInfo var "ULift Int" (· <| ULift Int) r
+
+/--
+Format the counter-examples found in a test failure.
+-/
+def formatFailure (s : String) (xs : List String) (n : Nat) : String :=
+  let counter := String.intercalate "\n" xs
+  let parts := [
+    "\n===================",
+    s,
+    counter,
+    s!"({n} shrinks)",
+    "-------------------"
+  ]
+  String.intercalate "\n" parts
+
+/--
+Increase the number of shrinking steps in a test result.
+-/
+def addShrinks (n : Nat) : MetaTestResult p → MetaTestResult p
+  | MetaTestResult.failure p pf xs m => MetaTestResult.failure p pf xs (m + n)
+  | p => p
+
+universe u in
+instance {α : Type u} {m : Type u → Type _} [Pure m] : Inhabited (OptionT m α) :=
+  ⟨(pure none : m (Option α))⟩
+
+variable {α : Sort _}
+
+/-- Shrink a counter-example `x` by using `Shrinkable.shrink x`, picking the first
+candidate that falsifies a property and recursively shrinking that one.
+The process is guaranteed to terminate because `shrink x` produces
+a proof that all the values it produces are smaller (according to `SizeOf`)
+than `x`. -/
+partial def minimizeAux [SampleableExt α] {β : α → Prop} [∀ x, MetaTestable (β x)] (cfg : Configuration)
+    (var : String) (x : SampleableExt.proxy α) (n : Nat) :
+    OptionT Gen (Σ x, MetaTestResult (β (SampleableExt.interp x))) := do
+  let candidates := SampleableExt.shrink.shrink x
+  if cfg.traceShrinkCandidates then
+    slimTrace s!"Candidates for {var} := {repr x}:\n  {repr candidates}"
+  for candidate in candidates do
+    if cfg.traceShrinkCandidates then
+      slimTrace s!"Trying {var} := {repr candidate}"
+    let res ← OptionT.lift <| MetaTestable.runProp (β (SampleableExt.interp candidate)) cfg true sorry
+    if res.isFailure then
+      if cfg.traceShrink then
+        slimTrace s!"{var} shrunk to {repr candidate} from {repr x}"
+      let currentStep := OptionT.lift <| return Sigma.mk candidate (addShrinks (n + 1) res)
+      let nextStep := minimizeAux cfg var candidate (n + 1)
+      return ← (nextStep <|> currentStep)
+  if cfg.traceShrink then
+    slimTrace s!"No shrinking possible for {var} := {repr x}"
+  failure
+
+/-- Once a property fails to hold on an example, look for smaller counter-examples
+to show the user. -/
+def minimize [SampleableExt α] {β : α → Prop} [∀ x, MetaTestable (β x)] (cfg : Configuration)
+    (var : String) (x : SampleableExt.proxy α) (r : MetaTestResult (β <| SampleableExt.interp x)) :
+    Gen (Σ x, MetaTestResult (β <| SampleableExt.interp x)) := do
+  if cfg.traceShrink then
+     slimTrace "Shrink"
+     slimTrace s!"Attempting to shrink {var} := {repr x}"
+  let res ← OptionT.run <| minimizeAux cfg var x 0
+  return res.getD ⟨x, r⟩
+
+/-- Test a universal property by creating a sample of the right type and instantiating the
+bound variable with it. -/
+instance varTestable [SampleableExt α] {β : α → Prop} [∀ x, MetaTestable (β x)] :
+    MetaTestable (NamedBinder var <| ∀ x : α, β x) where
+  run := fun cfg min e => do
+    let x ← SampleableExt.sample
+    if cfg.traceSuccesses || cfg.traceDiscarded then
+      slimTrace s!"{var} := {repr x}"
+    let r ← MetaTestable.runProp (β <| SampleableExt.interp x) cfg false e
+    let ⟨finalX, finalR⟩ ←
+      if isFailure r then
+        if cfg.traceSuccesses then
+          slimTrace s!"{var} := {repr x} is a failure"
+        if min then
+          minimize cfg var x r
+        else
+          pure ⟨x, r⟩
+      else
+        pure ⟨x, r⟩
+    return addVarInfo var finalX (· <| SampleableExt.interp finalX) finalR
+
+/-- Test a universal property about propositions -/
+instance propVarTestable {β : Prop → Prop} [∀ b : Bool, MetaTestable (β b)] :
+  MetaTestable (NamedBinder var <| ∀ p : Prop, β p)
+where
+  run := fun cfg min e =>
+    imp (fun h (b : Bool) => h b) <$> MetaTestable.runProp (NamedBinder var <| ∀ b : Bool, β b) cfg min e
+
+instance (priority := high) unusedVarTestable {β : Prop} [Nonempty α] [MetaTestable β] :
+  MetaTestable (NamedBinder var (α → β))
+where
+  run := fun cfg min e => do
+    if cfg.traceDiscarded || cfg.traceSuccesses then
+      slimTrace s!"{var} is unused"
+    let r ← MetaTestable.runProp β cfg min e
+    let finalR := addInfo s!"{var} is irrelevant (unused)" id r
+    return imp (· <| Classical.ofNonempty) finalR (PSum.inr <| fun x _ => x)
+
+instance (priority := 2000) subtypeVarTestable {p : α → Prop} {β : α → Prop}
+    [∀ x, PrintableProp (p x)]
+    [∀ x, MetaTestable (β x)]
+    [SampleableExt (Subtype p)] {var'} :
+    MetaTestable (NamedBinder var <| (x : α) → NamedBinder var' <| p x → β x) where
+  run cfg min e :=
+    letI (x : Subtype p) : MetaTestable (β x) :=
+      { run := fun cfg min e => do
+          let r ← MetaTestable.runProp (β x.val) cfg min e
+          return addInfo s!"guard: {printProp (p x)} (by construction)" id r (PSum.inr id) }
+    do
+      let r ← @MetaTestable.run (∀ x : Subtype p, β x.val) (@varTestable var _ _ _ _) cfg min e
+      have := by simp [Subtype.forall, NamedBinder]
+      return iff this r
+
+instance (priority := low) decidableTestable {p : Prop} [PrintableProp p] [Decidable p] :
+    MetaTestable p where
+  run := fun _ _ _ =>
+    if h : p then
+      return success (PSum.inr h)
+    else
+      let s := printProp p
+      return failure h sorry [s!"issue: {s} does not hold"] 0
+
+end MetaTestable
+
+#check PrintableProp
+
+
+section IO
+open MetaTestResult
+
+namespace MetaTestable
+/-- Execute `cmd` and repeat every time the result is `gaveUp` (at most `n` times). -/
+def retry (cmd : Rand (MetaTestResult p)) : Nat → Rand (MetaTestResult p)
+  | 0 => return MetaTestResult.gaveUp 1
+  | n+1 => do
+    let r ← cmd
+    match r with
+    | .success hp => return success hp
+    | .failure h pf xs n => return failure h pf xs n
+    | .gaveUp _ => retry cmd n
+    | .mismatch s => return .mismatch s
+
+/-- Count the number of times the test procedure gave up. -/
+def giveUp (x : Nat) : MetaTestResult p → MetaTestResult p
+  | success (PSum.inl ()) => gaveUp x
+  | success (PSum.inr p) => success <| (PSum.inr p)
+  | gaveUp n => gaveUp <| n + x
+  | MetaTestResult.failure h pf xs n => failure h pf xs n
+  | mismatch _ => gaveUp x
+
+end MetaTestable
+
+/-- Try `n` times to find a counter-example for `p`. -/
+def MetaTestable.runSuiteAux (p : Prop) [MetaTestable p] (cfg : Configuration) :
+    MetaTestResult p → Nat → Rand (MetaTestResult p)
+  | r, 0 => return r
+  | r, n+1 => do
+    let size := (cfg.numInst - n - 1) * cfg.maxSize / cfg.numInst
+    if cfg.traceSuccesses then
+      slimTrace s!"New sample"
+      slimTrace s!"Retrying up to {cfg.numRetries} times until guards hold"
+    let x ← retry (ReaderT.run (MetaTestable.runProp p cfg true sorry) ⟨size⟩) cfg.numRetries
+    match x with
+    | success (PSum.inl ()) => runSuiteAux p cfg r n
+    | gaveUp g => runSuiteAux p cfg (giveUp g r) n
+    | _ => return x
+
+/-- Try to find a counter-example of `p`. -/
+def MetaTestable.runSuite (p : Prop) [MetaTestable p] (cfg : Configuration := {}) : Rand (MetaTestResult p) :=
+  MetaTestable.runSuiteAux p cfg (success <| PSum.inl ()) cfg.numInst
+
+/-- Run a test suite for `p` in `BaseIO` using the global RNG in `stdGenRef`. -/
+def MetaTestable.checkIO (p : Prop) [MetaTestable p] (cfg : Configuration := {}) : BaseIO (MetaTestResult p) :=
+  letI : MonadLift Id BaseIO := ⟨fun f => return Id.run f⟩
+  match cfg.randomSeed with
+  | none => runRand (MetaTestable.runSuite p cfg)
+  | some seed => runRandWith seed (MetaTestable.runSuite p cfg)
+
+end IO
+
+open Decorations in
+/-- Run a test suite for `p` and throw an exception if `p` does not hold. -/
+def MetaTestable.check (p : Prop) (cfg : Configuration := {})
+    (p' : Decorations.DecorationsOf p := by mk_decorations) [MetaTestable p'] : Lean.CoreM PUnit := do
+  match ← MetaTestable.checkIO p' cfg with
+  | MetaTestResult.success _ => if !cfg.quiet then Lean.logInfo "Unable to find a counter-example"
+  | MetaTestResult.gaveUp n =>
+    if !cfg.quiet then
+      let msg := s!"Gave up after failing to generate values that fulfill the preconditions {n} times."
+      Lean.logWarning msg
+  | MetaTestResult.mismatch s =>
+    if !cfg.quiet then
+      let msg := s!"Mismatch: {s}"
+      Lean.logWarning msg
+  | MetaTestResult.failure _ _ xs n =>
+    let msg := "Found a counter-example!"
+    if cfg.quiet then
+      Lean.throwError msg
+    else
+      Lean.throwError <| formatFailure msg xs n
+
+-- #eval MetaTestable.check (∀ (x y z a : Nat) (h1 : 3 < x) (h2 : 3 < y), x - y = y - x)
+--   Configuration.verbose
+-- #eval MetaTestable.check (∀ x : Nat, ∀ y : Nat, x + y = y + x) Configuration.verbose
+-- #eval MetaTestable.check (∀ (x : (Nat × Nat)), x.fst - x.snd - 10 = x.snd - x.fst - 10)
+--   Configuration.verbose
+-- #eval MetaTestable.check (∀ (x : Nat) (h : 10 < x), 5 < x) Configuration.verbose
+
+macro tk:"#test " e:term : command => `(command| #eval%$tk MetaTestable.check $e)
+
+-- #test ∀ (x : Nat) (h : 5 < x), 10 < x
+-- #test ∀ (x : Nat) (h : 10 < x), 5 < x
+
+end Plausible

--- a/Plausible/MetaTestable.lean
+++ b/Plausible/MetaTestable.lean
@@ -179,6 +179,16 @@ def equality? (e: Expr): MetaM (Option (Expr × Expr × Expr)) := do
     return none
 end Matching
 
+open Lean Meta
+abbrev MRand := RandT MetaM
+
+instance : MonadLift Rand MRand where
+  monadLift := fun x s => return x.run s
+
+abbrev MGen (α : Type) := ReaderT (ULift Nat) MRand α
+
+instance : MonadLift Gen MGen where
+  monadLift := fun x n => x.run n.down
 
 /-- Result of trying to disprove `p` -/
 inductive MetaTestResult (p : Prop) where

--- a/Plausible/RandomSearch.lean
+++ b/Plausible/RandomSearch.lean
@@ -1,0 +1,147 @@
+import Plausible.MetaTestable
+open Lean Meta Elab Term
+
+namespace Plausible
+
+#check Decidable.not_not
+#check Classical.choice
+
+open Classical in
+theorem not_not (p: Prop) : ¬ ¬ p → p :=
+  fun h' => if h : p then h else absurd h h'
+
+open Classical in
+theorem not_and {p q : Prop} : ¬ (p ∧ q) →  ¬ p ∨ ¬ q :=
+  fun h => if hp : p then Or.inr fun hq => h ⟨hp, hq⟩ else Or.inl hp
+
+theorem induced_or {p₁ q₁ p₂ q₂ : Prop} (h₁ : p₁ → q₁) (h₂ : p₂ → q₂) : p₁ ∨ p₂ → q₁ ∨ q₂
+  | Or.inl h => Or.inl (h₁ h)
+  | Or.inr h => Or.inr (h₂ h)
+
+theorem induced_and {p₁ q₁ p₂ q₂ : Prop} (h₁ : p₁ → q₁) (h₂ : p₂ → q₂) : p₁ ∧ p₂ → q₁ ∧ q₂
+  | ⟨h1, h2⟩ => ⟨h₁ h1, h₂ h2⟩
+
+theorem induced_exists {p q : α → Prop}(f : ∀x : α, p x → q x) : (∃ x, p x) → ∃ x, q x
+  | ⟨x, h⟩ => ⟨x, f x h⟩
+
+theorem not_or_mp {p q : Prop} (h : ¬ (p ∨ q)) : ¬ p ∧ ¬ q :=
+  ⟨fun h' => h (Or.inl h'), fun h' => h (Or.inr h')⟩
+
+theorem not_forall {p : α → Prop} : ¬ (∀ x, p x) →  ∃ x, ¬ p x := by
+  intro h
+  apply not_not
+  intro contra
+  have l : ∀ (x : α), p x := by
+    intro x
+    by_cases h' : p x
+    · exact h'
+    · exfalso
+      exact contra ⟨x, h'⟩
+  contradiction
+
+
+#print not_not
+#check not_and_of_not_or_not
+#check not_or
+#check not_exists_of_forall_not
+#check not_forall_of_exists_not
+#check Iff.mp
+
+partial def negate (e: Expr) : MetaM <| Expr × Expr := do
+  match ← notProp? e with
+  | some e' =>
+    let negProof ← mkAppOptM ``id #[e]
+    return (e', negProof)
+  | _ =>
+  match ← andProp? e with
+  | (some e₁, some e₂) =>
+    let (negProp₁, negProof₁) ← negate e₁
+    let (negProp₂, negProof₂) ← negate e₂
+    let negProp ← mkAppM ``Or #[negProp₁, negProp₂]
+    let negPf ← withLocalDeclD `h (← mkAppM ``Not #[negProp]) fun h => do
+      let h' ← mkAppM ``not_or_mp #[h]
+      let negProof ← mkAppM ``induced_and #[negProof₁, negProof₂, h']
+      mkLambdaFVars #[h] negProof
+    return (negProp, negPf)
+  | _ =>
+  match ← orProp? e with
+  | (some e₁, some e₂) =>
+    let (negProp₁, negProof₁) ← negate e₁
+    let (negProp₂, negProof₂) ← negate e₂
+    let negProp ← mkAppM ``And #[negProp₁, negProp₂]
+    let negPf ← withLocalDeclD `h (← mkAppM ``Not #[negProp]) fun h => do
+      let h' ← mkAppM ``not_and #[h]
+      let negProof ← mkAppM ``induced_or #[negProof₁, negProof₂, h']
+      mkLambdaFVars #[h] negProof
+    return (negProp, negPf)
+  | _ =>
+  match ← existsProp? e with
+  | (some p, some α) =>
+    logInfo m!"Negating existential quantifier {← ppExpr e}, family: {← ppExpr p}, domain: {← ppExpr α}"
+    let (negProp, negProofFamily) ← withLocalDeclD `x α fun x => do
+      let y ← mkAppM' p #[x]
+      let (y, _) ← dsimp y {}
+      let (negProp, negProof) ← negate y
+      pure (← mkForallFVars #[x] negProp, ← mkLambdaFVars #[x] negProof)
+    logInfo m!"Negation of {← ppExpr e} is {← ppExpr negProp}"
+    let negPf ← withLocalDeclD `h (← mkAppM ``Not #[negProp]) fun h => do
+      let h' ← mkAppM ``not_forall #[h]
+      let negProof ← mkAppM ``induced_exists #[negProofFamily, h']
+      mkLambdaFVars #[h] negProof
+    return (negProp, negPf)
+  | _ =>
+    let negProp ← mkAppM ``Not #[e]
+    let negProof ← mkAppM ``not_not #[e]
+    return (negProp, negProof)
+
+open Elab Term
+elab "neg_neg" t:term : term => do
+  let e ← elabTerm t none
+  let (negProp, negProof) ← negate e
+  let pfType ← inferType negProof
+  -- disproof of negation implies `e`
+  let goal ← mkArrow (← mkAppM ``Not #[negProp]) e
+  let check ← isDefEq pfType goal
+  logInfo m!"Negation of {← ppExpr e} is {← ppExpr negProp}"
+  logInfo m!"Proof of negation is {← ppExpr negProof} with type {← ppExpr <| ← inferType negProof}, should be {← ppExpr goal}"
+  logInfo m!"check: {check}"
+  return negProp
+
+#check neg_neg (1 = 4)
+
+#check neg_neg ¬(1 = 4)
+
+#check neg_neg ¬(1 = 4) ∧ (2 < 4)
+
+#check neg_neg (1 = 4) ∨ (¬ (2 < 4))
+
+#check neg_neg ∃ x : Nat, x > 0
+
+open Lean.Parser.Tactic Tactic
+syntax (name := searchSyntax) "random_search" (config)? : tactic
+elab_rules : tactic | `(tactic| random_search $[$cfg]?) => withMainContext do
+  let cfg ← elabConfig (mkOptionalNode cfg)  let (_, g) ← (← getMainGoal).revert ((← getLocalHyps).map (Expr.fvarId!))
+  let cfg := { cfg with
+    traceDiscarded := cfg.traceDiscarded || (← isTracingEnabledFor `plausible.discarded),
+    traceSuccesses := cfg.traceSuccesses || (← isTracingEnabledFor `plausible.success),
+    traceShrink := cfg.traceShrink || (← isTracingEnabledFor `plausible.shrink.steps),
+    traceShrinkCandidates := cfg.traceShrinkCandidates
+      || (← isTracingEnabledFor `plausible.shrink.candidates) }
+  g.withContext do
+  let tgt ← g.getType
+  let (negProp, negProof) ← negate tgt
+  match ← disproveM? cfg negProp with
+  | some pf =>
+    let pf' ← mkAppM' negProof #[pf]
+    logInfo m!"Found a proof by negated counter-example!"
+    g.assign pf'
+  | none =>
+    throwError "could not find a proof by negated counter-example"
+
+example : ¬ (1 = 4) := by
+  random_search
+
+example : ∃ n : Nat, n > 0 ∧ n < 4 := by
+  random_search
+
+end Plausible

--- a/Plausible/RandomSearch.lean
+++ b/Plausible/RandomSearch.lean
@@ -1,10 +1,13 @@
 import Plausible.MetaTestable
+/-!
+## Random Search
+
+The `random_search` tactic tries to prove a result by searching for a counter-example to its negation using `MetaTestable`. If a counter-example is found, we can prove the result by showing that the negation is false.
+-/
+
 open Lean Meta Elab Term
 
 namespace Plausible
-
-#check Decidable.not_not
-#check Classical.choice
 
 open Classical in
 theorem not_not (p: Prop) : ¬ ¬ p → p :=
@@ -39,13 +42,6 @@ theorem not_forall {p : α → Prop} : ¬ (∀ x, p x) →  ∃ x, ¬ p x := by
       exact contra ⟨x, h'⟩
   contradiction
 
-
-#print not_not
-#check not_and_of_not_or_not
-#check not_or
-#check not_exists_of_forall_not
-#check not_forall_of_exists_not
-#check Iff.mp
 
 partial def negate (e: Expr) : MetaM <| Expr × Expr := do
   match ← notProp? e with
@@ -107,16 +103,6 @@ elab "neg_neg" t:term : term => do
   logInfo m!"check: {check}"
   return negProp
 
-#check neg_neg (1 = 4)
-
-#check neg_neg ¬(1 = 4)
-
-#check neg_neg ¬(1 = 4) ∧ (2 < 4)
-
-#check neg_neg (1 = 4) ∨ (¬ (2 < 4))
-
-#check neg_neg ∃ x : Nat, x > 0
-
 open Lean.Parser.Tactic Tactic
 syntax (name := searchSyntax) "random_search" (config)? : tactic
 elab_rules : tactic | `(tactic| random_search $[$cfg]?) => withMainContext do
@@ -137,11 +123,5 @@ elab_rules : tactic | `(tactic| random_search $[$cfg]?) => withMainContext do
     g.assign pf'
   | none =>
     throwError "could not find a proof by negated counter-example"
-
-example : ¬ (1 = 4) := by
-  random_search
-
-example : ∃ n : Nat, n > 0 ∧ n < 4 := by
-  random_search
 
 end Plausible

--- a/Plausible/Vacuous.lean
+++ b/Plausible/Vacuous.lean
@@ -1,0 +1,69 @@
+import Lean
+import Plausible
+import Plausible.MetaTestable
+
+open Lean Meta Elab Tactic Plausible
+
+partial def proveVacuous? (p: Expr) (cfg : Configuration := {})  : MetaM <| Option Expr := do
+  match p with
+  | .forallE n d b bi =>
+    withLocalDecl n bi d fun x => do
+      let b := b.instantiate1 x
+      let contra? ← try
+        disproveM? cfg d -- proof of ¬d
+      catch _ =>
+        pure none
+      match contra? with
+      | some contra =>
+        logInfo m!"Vacuous Implication. Hypothesis {← ppExpr d} is never satisfied"
+        let pfFalse ← mkAppM' contra #[x]
+        let pfBody ← mkAppOptM ``False.elim #[b, pfFalse]
+        mkLambdaFVars #[x] pfBody
+      | none =>
+        let inner ← proveVacuous? b cfg
+        inner.mapM fun pf => mkLambdaFVars #[x] pf
+  | _ =>
+    return none
+
+open Lean.Parser.Tactic
+
+syntax (name := vacuousSyntax) "vacuous" (config)? : tactic
+elab_rules : tactic | `(tactic| vacuous $[$cfg]?) => withMainContext do
+  let cfg ← elabConfig (mkOptionalNode cfg)  let (_, g) ← (← getMainGoal).revert ((← getLocalHyps).map (Expr.fvarId!))
+  let cfg := { cfg with
+    traceDiscarded := cfg.traceDiscarded || (← isTracingEnabledFor `plausible.discarded),
+    traceSuccesses := cfg.traceSuccesses || (← isTracingEnabledFor `plausible.success),
+    traceShrink := cfg.traceShrink || (← isTracingEnabledFor `plausible.shrink.steps),
+    traceShrinkCandidates := cfg.traceShrinkCandidates
+      || (← isTracingEnabledFor `plausible.shrink.candidates) }
+  g.withContext do
+  let tgt ← g.getType
+  match ← proveVacuous? tgt cfg with
+  | some pf =>
+    g.assign pf
+  | none =>
+    throwError "no vacuous proof found"
+
+
+elab "prove_vacuous" type:term : term => do
+  let p ← Term.elabType type
+  let vacuous ← proveVacuous? p
+  match vacuous with
+  | some pf =>
+    return pf
+  | none =>
+    logWarning m!"No vacuous proof found"
+    return mkConst ``False
+
+
+#check prove_vacuous ((2 : Nat) < 1) → 1 ≤ 3
+
+#check prove_vacuous (∀ n: Nat, n < (4: Nat)) → 1 ≤ 3
+
+example : (∀ n: Nat, n < (4: Nat)) → 1 ≤ 3 := by vacuous
+
+example : (2 : Nat) < 1 → 1 ≤ 3 := by vacuous
+
+example (h: ∀ n: Nat, n < (4: Nat)) : 4 ≤ 3 := by vacuous
+
+example (m: Nat) (h: ∀ n: Nat, n < (4: Nat)) : m ≤ 3 := by vacuous

--- a/Plausible/Vacuous.lean
+++ b/Plausible/Vacuous.lean
@@ -1,6 +1,11 @@
 import Lean
 import Plausible
 import Plausible.MetaTestable
+/-!
+## Vacuous Implication
+
+The `vacuous` tactic is used to prove vacuous implications. We use the plausible search for counterexamples (actually at the `MetaTestable` level) to find a counterexample to the hypothesis. If a counterexample is found, we can prove the vacuous implication by showing that the hypothesis is never satisfied.
+-/
 
 open Lean Meta Elab Tactic Plausible
 

--- a/Plausible/Vacuous.lean
+++ b/Plausible/Vacuous.lean
@@ -43,27 +43,3 @@ elab_rules : tactic | `(tactic| vacuous $[$cfg]?) => withMainContext do
     g.assign pf
   | none =>
     throwError "no vacuous proof found"
-
-
-elab "prove_vacuous" type:term : term => do
-  let p ← Term.elabType type
-  let vacuous ← proveVacuous? p
-  match vacuous with
-  | some pf =>
-    return pf
-  | none =>
-    logWarning m!"No vacuous proof found"
-    return mkConst ``False
-
-
-#check prove_vacuous ((2 : Nat) < 1) → 1 ≤ 3
-
-#check prove_vacuous (∀ n: Nat, n < (4: Nat)) → 1 ≤ 3
-
-example : (∀ n: Nat, n < (4: Nat)) → 1 ≤ 3 := by vacuous
-
-example : (2 : Nat) < 1 → 1 ≤ 3 := by vacuous
-
-example (h: ∀ n: Nat, n < (4: Nat)) : 4 ≤ 3 := by vacuous
-
-example (m: Nat) (h: ∀ n: Nat, n < (4: Nat)) : m ≤ 3 := by vacuous

--- a/Test/MetaTestable.lean
+++ b/Test/MetaTestable.lean
@@ -147,14 +147,48 @@ def de : Decorations.DecorationsOf (∀ a b : Nat, a ≤ b) := by mk_decorations
 AppBuilder for 'mkAppM', result contains metavariables
   SampleableExt Nat
 -/
-set_option pp.universes true
+set_option pp.universes true in
 #eval MetaTestable.check (∀ (a : Nat), a < 1) (propExpr := Lean.Expr.forallE `a (Lean.Expr.const `Nat []) (Lean.Expr.const `False []) (Lean.BinderInfo.default))
 
-set_option pp.all true in
--- #eval MetaTestable.check (∀ (a b : Nat), a < b) (propExpr := Lean.Expr.forallE `a (Lean.Expr.const `Nat []) (Lean.Expr.const `False []) (Lean.BinderInfo.default))
 
-def samp := SampleableExt Nat
-#print samp
+#eval MetaTestable.check (∀ (a b : Nat), a < b) (propExpr := (Lean.Expr.forallE
+  `a
+  (Lean.Expr.const `Nat [])
+  (Lean.Expr.forallE
+    `b
+    (Lean.Expr.const `Nat [])
+    (Lean.Expr.app
+      (Lean.Expr.app
+        (Lean.Expr.app
+          (Lean.Expr.app
+            (Lean.Expr.const `LT.lt [Level.succ Level.zero])
+            (Lean.Expr.const `Nat []))
+          (Lean.Expr.const `instLTNat []))
+        (Lean.Expr.bvar 1))
+      (Lean.Expr.bvar 0))
+    (Lean.BinderInfo.default))
+  (Lean.BinderInfo.default)))
 
-#synth SampleableExt Nat
-#check Nat.sampleableExt
+
+#eval MetaTestable.check (∀ (a b : Nat), a < 0) (propExpr := (Lean.Expr.forallE
+  `a
+  (Lean.Expr.const `Nat [])
+  (Lean.Expr.forallE
+    `b
+    (Lean.Expr.const `Nat [])
+    (Lean.Expr.app
+      (Lean.Expr.app
+        (Lean.Expr.app
+          (Lean.Expr.app
+            (Lean.Expr.const `LT.lt [Level.succ Level.zero])
+            (Lean.Expr.const `Nat []))
+          (Lean.Expr.const `instLTNat []))
+        (Lean.Expr.bvar 1))
+      (Lean.Expr.lit (Lean.Literal.natVal 0)))
+    (Lean.BinderInfo.default))
+  (Lean.BinderInfo.default)))
+
+#expr ∀ (a b : Nat), a < b
+#expr ∀ (a b : Nat), a < 0
+
+#check Lean.Expr.lit (Lean.Literal.natVal 0)

--- a/Test/MetaTestable.lean
+++ b/Test/MetaTestable.lean
@@ -141,7 +141,7 @@ def de : Decorations.DecorationsOf (∀ a b : Nat, a ≤ b) := by mk_decorations
 #synth MetaTestable (NamedBinder "a" (∀ (a : Nat), NamedBinder "b" (∀ (b : Nat), a ≤ b)))
 
 set_option pp.universes true in
-#eval MetaTestable.check (∀ (a : Nat), False) (propExpr := Lean.Expr.forallE `a (Lean.Expr.const `Nat []) (Lean.Expr.const `False []) (Lean.BinderInfo.default))
+#eval MetaTestable.check (∀ (_a : Nat), False) (propExpr := Lean.Expr.forallE `a (Lean.Expr.const `Nat []) (Lean.Expr.const `False []) (Lean.BinderInfo.default))
 
 /-
 AppBuilder for 'mkAppM', result contains metavariables
@@ -189,7 +189,7 @@ set_option linter.unusedVariables false in
   (Lean.BinderInfo.default)))
 
 #expr ∀ (a b : Nat), a < b
-#expr ∀ (a b : Nat), a < 0
+#expr ∀ (a _b : Nat), a < 0
 
 #check Lean.Expr.lit (Lean.Literal.natVal 0)
 
@@ -208,3 +208,16 @@ elab "disprove%" t:term : term => do
 #check disprove% ∀ (a b : Nat), a < b ∨ b < a
 
 #check disprove% False ∧ False
+
+def eg {p: Prop}(h : ¬¬p) : p :=
+  by
+  by_cases h':p
+  · exact h'
+  · exfalso
+    contradiction
+
+/-
+def eg : ∀ {p : Prop}, ¬¬p → p :=
+fun {p} h => if h' : p then h' else False.elim (absurd h' h)
+-/
+#print eg

--- a/Test/MetaTestable.lean
+++ b/Test/MetaTestable.lean
@@ -142,3 +142,19 @@ def de : Decorations.DecorationsOf (∀ a b : Nat, a ≤ b) := by mk_decorations
 
 
 #eval MetaTestable.check (∀ (a : Nat), False) (propExpr := Lean.Expr.forallE `a (Lean.Expr.const `Nat []) (Lean.Expr.const `False []) (Lean.BinderInfo.default))
+
+/-
+AppBuilder for 'mkAppM', result contains metavariables
+  SampleableExt Nat
+-/
+set_option pp.universes true
+#eval MetaTestable.check (∀ (a : Nat), a < 1) (propExpr := Lean.Expr.forallE `a (Lean.Expr.const `Nat []) (Lean.Expr.const `False []) (Lean.BinderInfo.default))
+
+set_option pp.all true in
+-- #eval MetaTestable.check (∀ (a b : Nat), a < b) (propExpr := Lean.Expr.forallE `a (Lean.Expr.const `Nat []) (Lean.Expr.const `False []) (Lean.BinderInfo.default))
+
+def samp := SampleableExt Nat
+#print samp
+
+#synth SampleableExt Nat
+#check Nat.sampleableExt

--- a/Test/MetaTestable.lean
+++ b/Test/MetaTestable.lean
@@ -140,7 +140,7 @@ def de : Decorations.DecorationsOf (∀ a b : Nat, a ≤ b) := by mk_decorations
 
 #synth MetaTestable (NamedBinder "a" (∀ (a : Nat), NamedBinder "b" (∀ (b : Nat), a ≤ b)))
 
-
+set_option pp.universes true in
 #eval MetaTestable.check (∀ (a : Nat), False) (propExpr := Lean.Expr.forallE `a (Lean.Expr.const `Nat []) (Lean.Expr.const `False []) (Lean.BinderInfo.default))
 
 /-
@@ -169,7 +169,7 @@ set_option pp.universes true in
     (Lean.BinderInfo.default))
   (Lean.BinderInfo.default)))
 
-
+set_option linter.unusedVariables false in
 #eval MetaTestable.check (∀ (a b : Nat), a < 0) (propExpr := (Lean.Expr.forallE
   `a
   (Lean.Expr.const `Nat [])
@@ -192,3 +192,15 @@ set_option pp.universes true in
 #expr ∀ (a b : Nat), a < 0
 
 #check Lean.Expr.lit (Lean.Literal.natVal 0)
+
+#expr Expr → MetaM (Option Expr)
+
+
+elab "disprove%" t:term : term => do
+  let tgt ← elabType t
+  let cfg : Configuration := {}
+  let (some code') ← disproveM? cfg tgt | throwError "disprove% failed"
+  logInfo s!"disproof: {← ppExpr code'}; \ntype: {← ppExpr <| (← inferType code')}"
+  return tgt
+
+#check disprove% ∀ (a b : Nat), a < b

--- a/Test/MetaTestable.lean
+++ b/Test/MetaTestable.lean
@@ -204,3 +204,7 @@ elab "disprove%" t:term : term => do
   return tgt
 
 #check disprove% ∀ (a b : Nat), a < b
+
+#check disprove% ∀ (a b : Nat), a < b ∨ b < a
+
+#check disprove% False ∧ False

--- a/Test/MetaTestable.lean
+++ b/Test/MetaTestable.lean
@@ -1,0 +1,95 @@
+import Lean
+import Plausible.MetaTestable
+
+open Plausible Plausible.MetaTestable  Lean Meta Elab Term
+
+open Lean Elab Term in
+elab "#decompose_prop" t:term : command =>
+  Command.liftTermElabM  do
+    let e ← elabType t
+    match ← orProp? e with
+    | (some α, some β) => logInfo s!"Or: {← ppExpr α}; {← ppExpr β}"
+    | _ => pure ()
+    match ← andProp? e with
+    | (some α, some β) => logInfo s!"And: {← ppExpr α}; {← ppExpr β}"
+    | _ => pure ()
+    match ← existsProp? e with
+    | (some α, some β) => logInfo s!"Exists: {← ppExpr α}; domain {← ppExpr β}"
+    | _ => pure ()
+    match ← forallProp? e with
+    | (some α, some β) => logInfo s!"Forall: {← ppExpr α}; domain {← ppExpr β}"
+    | _ => pure ()
+    match ← impProp? e with
+    | (some α, some β) => logInfo s!"Imp: {← ppExpr α}; {← ppExpr β}"
+    | _ => pure ()
+    match ← eqlProp? e with
+    | some (α, a, b) => logInfo s!"Eq: {← ppExpr α}; {← ppExpr a} and {← ppExpr b}"
+    | _ => pure ()
+    match ← iffProp? e with
+    | some (α, β) => logInfo s!"Iff: {← ppExpr α}; {← ppExpr β}"
+    | _ => pure ()
+
+/-- info: Forall: fun x => x = 0 ∨ x ≠ 0; domain Nat -/
+#guard_msgs in
+#decompose_prop ∀ (n: Nat), n = 0 ∨ n ≠ 0
+
+/-- info: Forall: fun x => x = 0 ∨ x ≠ 0; domain Nat -/
+#guard_msgs in
+#decompose_prop NamedBinder "blah" <| ∀ (n: Nat), n = 0 ∨ n ≠ 0
+
+/-- info: Or: 1 = 0; 2 ≠ 0 -/
+#guard_msgs in
+#decompose_prop 1 = 0 ∨ 2 ≠ 0
+
+/-- info: And: 1 = 0; 2 ≠ 0 -/
+#guard_msgs in
+#decompose_prop 1 = 0 ∧ 2 ≠ 0
+
+/-- info: Exists: fun n => n = 0 ∨ n ≠ 0; domain Nat -/
+#guard_msgs in
+#decompose_prop ∃ (n: Nat), n = 0 ∨ n ≠ 0
+
+#check List.nil
+
+#check MetaTestResult.failure
+
+elab "mk_failure%" prop:term ";" pf:term ";" : term => do
+  let prop ← elabType prop
+  let notProp ← mkAppM ``Not #[prop]
+  let pf ← elabTerm pf notProp
+  let lst ← mkAppOptM ``List.nil #[mkConst ``String]
+  let pfExpr := Lean.Expr.letE
+    `pf_var
+    (notProp)
+    (pf)
+    (Lean.Expr.app
+      (Lean.Expr.const `Lean.Expr.fvar [])
+      (Lean.Expr.app
+        (Lean.Expr.const `Lean.FVarId.mk [])
+        (Lean.Expr.app (Lean.Expr.const `Lean.Name.mkStr1 []) (Lean.Expr.lit (Lean.Literal.strVal "pf_var")))))
+    false
+  logInfo s!"{repr pfExpr}"
+  mkAppOptM ``MetaTestResult.failure #[prop, pf, pfExpr, lst, mkConst ``Nat.zero]
+
+set_option pp.proofs true in
+#check mk_failure% False ; fun (x: False) ↦ x ;
+
+elab "#expr" e:term : command =>
+  Command.liftTermElabM  do
+    let e ← elabTerm e none
+    logInfo s!"{repr e}"
+    logInfo s!"{← reduce e}"
+
+#check Expr.fvar {name := `n}
+
+/-
+Lean.Expr.fvar (Lean.FVarId.mk (Lean.Name.mkStr1 "n"))
+-/
+#expr (
+    let pf_var : Nat := 0
+    Expr.fvar {name := `pf_var})
+#expr Lean.mkConst ``Nat
+
+#check Lean.Expr.fvar (Lean.FVarId.mk (Lean.Name.mkStr1 "n"))
+
+#check Lean.Expr.mvar (Lean.MVarId.mk (Lean.Name.mkStr1 "n"))

--- a/Test/RandomSeach.lean
+++ b/Test/RandomSeach.lean
@@ -1,0 +1,42 @@
+import Plausible.RandomSearch
+
+open Plausible
+
+/-
+¬1 = 4 : Prop
+-/
+#check neg_neg (1 = 4)
+
+/-
+Negation of ¬1 = 4 is 1 = 4
+-/
+#check neg_neg ¬(1 = 4)
+
+/-
+Proof of negation is fun h =>
+  induced_and id (not_not (2 < 4))
+    (not_or_mp h) with type ¬(1 = 4 ∨ ¬2 < 4) → ¬1 = 4 ∧ 2 < 4, should be ¬(1 = 4 ∨ ¬2 < 4) → ¬1 = 4 ∧ 2 < 4
+-/
+#check neg_neg ¬(1 = 4) ∧ (2 < 4)
+
+/-
+check: true
+-/
+#check neg_neg (1 = 4) ∨ (¬ (2 < 4))
+
+/-
+check: true
+-/
+#check neg_neg ∃ x : Nat, x > 0
+
+example : ¬ (1 = 4) := by
+  /-
+  Found a proof by negated counter-example!
+  -/
+  random_search
+
+example : ∃ n : Nat, n > 0 ∧ n < 4 := by
+  /-
+  Found a proof by negated counter-example!
+  -/
+  random_search

--- a/Test/Vacuous.lean
+++ b/Test/Vacuous.lean
@@ -26,66 +26,12 @@ info: fun a => False.elim (of_decide_eq_false (Eq.refl false) a) : 2 < 1 → 1 �
 #guard_msgs in
 #check prove_vacuous ((2 : Nat) < 1) → 1 ≤ 3
 
-/--
-info:
-===================
-Found a counter-example!
-n := 5
-issue: 5 < 4 does not hold
-(0 shrinks)
--------------------
----
-info: Vacuous Implication. Hypothesis ∀ (n : Nat), n < 4 is never satisfied
----
-info: fun a =>
-  False.elim
-    (mt (fun x => x (Plausible.SampleableExt.interp 5)) (of_decide_eq_false (Eq.refl false))
-      a) : (∀ (n : Nat), n < 4) → 1 ≤ 3
--/
-#guard_msgs in
+-- We cannot use `guard_msgs` here because of random search. Need to add seeds as a parameter.
+
 #check prove_vacuous (∀ n: Nat, n < (4: Nat)) → 1 ≤ 3
 
-/--
-info:
-===================
-Found a counter-example!
-n := 5
-issue: 5 < 4 does not hold
-(0 shrinks)
--------------------
----
-info: Vacuous Implication. Hypothesis ∀ (n : Nat), n < 4 is never satisfied
--/
-#guard_msgs in
--- Can negate hypothesis in goal statement
 example : (∀ n: Nat, n < (4: Nat)) → 4 ≤ 3 := by vacuous
 
-/--
-info:
-===================
-Found a counter-example!
-n := 5
-issue: 5 < 4 does not hold
-(0 shrinks)
--------------------
----
-info: Vacuous Implication. Hypothesis ∀ (n : Nat), n < 4 is never satisfied
--/
-#guard_msgs in
--- Can negate hypothesis in local context
 example (h: ∀ n: Nat, n < (4: Nat)) : 4 ≤ 3 := by vacuous
 
-/--
-info:
-===================
-Found a counter-example!
-n := 5
-issue: 5 < 4 does not hold
-(0 shrinks)
--------------------
----
-info: Vacuous Implication. Hypothesis ∀ (n : Nat), n < 4 is never satisfied
--/
-#guard_msgs in
--- Can negate hypothesis other than the first one
 example (m: Nat) (h: ∀ n: Nat, n < (4: Nat)) : m ≤ 3 := by vacuous

--- a/Test/Vacuous.lean
+++ b/Test/Vacuous.lean
@@ -30,8 +30,8 @@ info: fun a => False.elim (of_decide_eq_false (Eq.refl false) a) : 2 < 1 → 1 �
 info:
 ===================
 Found a counter-example!
-n := 6
-issue: 6 < 4 does not hold
+n := 5
+issue: 5 < 4 does not hold
 (0 shrinks)
 -------------------
 ---
@@ -39,7 +39,7 @@ info: Vacuous Implication. Hypothesis ∀ (n : Nat), n < 4 is never satisfied
 ---
 info: fun a =>
   False.elim
-    (mt (fun x => x (Plausible.SampleableExt.interp 6)) (of_decide_eq_false (Eq.refl false))
+    (mt (fun x => x (Plausible.SampleableExt.interp 5)) (of_decide_eq_false (Eq.refl false))
       a) : (∀ (n : Nat), n < 4) → 1 ≤ 3
 -/
 #guard_msgs in
@@ -49,8 +49,8 @@ info: fun a =>
 info:
 ===================
 Found a counter-example!
-n := 6
-issue: 6 < 4 does not hold
+n := 5
+issue: 5 < 4 does not hold
 (0 shrinks)
 -------------------
 ---
@@ -64,8 +64,8 @@ example : (∀ n: Nat, n < (4: Nat)) → 4 ≤ 3 := by vacuous
 info:
 ===================
 Found a counter-example!
-n := 6
-issue: 6 < 4 does not hold
+n := 5
+issue: 5 < 4 does not hold
 (0 shrinks)
 -------------------
 ---
@@ -79,8 +79,8 @@ example (h: ∀ n: Nat, n < (4: Nat)) : 4 ≤ 3 := by vacuous
 info:
 ===================
 Found a counter-example!
-n := 6
-issue: 6 < 4 does not hold
+n := 5
+issue: 5 < 4 does not hold
 (0 shrinks)
 -------------------
 ---

--- a/Test/Vacuous.lean
+++ b/Test/Vacuous.lean
@@ -1,0 +1,91 @@
+import Plausible.Vacuous
+open Lean Meta Elab
+
+elab "prove_vacuous" type:term : term => do
+  let p ← Term.elabType type
+  let vacuous ← proveVacuous? p
+  match vacuous with
+  | some pf =>
+    return pf
+  | none =>
+    logWarning m!"No vacuous proof found"
+    return mkConst ``False
+
+/--
+info:
+===================
+Found a counter-example!
+issue: 2 < 1 does not hold
+(0 shrinks)
+-------------------
+---
+info: Vacuous Implication. Hypothesis 2 < 1 is never satisfied
+---
+info: fun a => False.elim (of_decide_eq_false (Eq.refl false) a) : 2 < 1 → 1 ≤ 3
+-/
+#guard_msgs in
+#check prove_vacuous ((2 : Nat) < 1) → 1 ≤ 3
+
+/--
+info:
+===================
+Found a counter-example!
+n := 6
+issue: 6 < 4 does not hold
+(0 shrinks)
+-------------------
+---
+info: Vacuous Implication. Hypothesis ∀ (n : Nat), n < 4 is never satisfied
+---
+info: fun a =>
+  False.elim
+    (mt (fun x => x (Plausible.SampleableExt.interp 6)) (of_decide_eq_false (Eq.refl false))
+      a) : (∀ (n : Nat), n < 4) → 1 ≤ 3
+-/
+#guard_msgs in
+#check prove_vacuous (∀ n: Nat, n < (4: Nat)) → 1 ≤ 3
+
+/--
+info:
+===================
+Found a counter-example!
+n := 6
+issue: 6 < 4 does not hold
+(0 shrinks)
+-------------------
+---
+info: Vacuous Implication. Hypothesis ∀ (n : Nat), n < 4 is never satisfied
+-/
+#guard_msgs in
+-- Can negate hypothesis in goal statement
+example : (∀ n: Nat, n < (4: Nat)) → 4 ≤ 3 := by vacuous
+
+/--
+info:
+===================
+Found a counter-example!
+n := 6
+issue: 6 < 4 does not hold
+(0 shrinks)
+-------------------
+---
+info: Vacuous Implication. Hypothesis ∀ (n : Nat), n < 4 is never satisfied
+-/
+#guard_msgs in
+-- Can negate hypothesis in local context
+example (h: ∀ n: Nat, n < (4: Nat)) : 4 ≤ 3 := by vacuous
+
+/--
+info:
+===================
+Found a counter-example!
+n := 6
+issue: 6 < 4 does not hold
+(0 shrinks)
+-------------------
+---
+info: Vacuous Implication. Hypothesis ∀ (n : Nat), n < 4 is never satisfied
+-/
+#guard_msgs in
+-- Can negate hypothesis other than the first one
+example (m: Nat) (h: ∀ n: Nat, n < (4: Nat)) : m ≤ 3 := by vacuous


### PR DESCRIPTION
* A new class `MetaTestable` is introduced that is similar to `Testable` but also keeps track of expressions for counterexamples by copying and modifying the code. 
* Tests show that in many cases `MetaTestable` can be inferred. There are limitations as in addition to `SampleableExt` we need `ToExpr` for the proxy type to build expressions.
* Using this, we write two new tactics: `vacuous` and `random_search`.
* The `vacuous` tactic tries to negate (a part of the) hypothesis to prove by vacuous implication.
* The `random_search` tactic negates the goal and tries to disprove it.