### PR TITLE
Gen type modifications

### DIFF
--- a/Plausible/Arbitrary.lean
+++ b/Plausible/Arbitrary.lean
@@ -13,7 +13,8 @@ The `Arbitrary` typeclass represents types for which there exists a
 random generator suitable for property-based testing, similar to
 Haskell QuickCheck's `Arbitrary` typeclass and Rocq/Coq QuickChick's `Gen` typeclass.
 
-(Note: the `Arbitrary` describes types which have *both* a generator & a shrinker,
+(Note: the `SampleableExt` involvs types which have *both* a generator & a shrinker,
+and possibly a non trivial `proxy` type,
 whereas `Arbitrary` describes types which have a generator only.)
 
 ## Main definitions
@@ -118,18 +119,20 @@ instance Bool.Arbitrary : Arbitrary Bool :=
   ⟨chooseAny Bool⟩
 
 /-- This can be specialized into customized `Arbitrary Char` instances.
-The resulting instance has `1 / length` chances of making an unrestricted choice of characters
-and it otherwise chooses a character from `chars` with uniform probabilities. -/
-def Char.arbitraryFromList (length : Nat) (chars : List Char) (pos : 0 < chars.length) :
+The resulting instance has `1 / p` chances of making an unrestricted choice of characters
+and it otherwise chooses a character from `chars` with uniform probability. -/
+def Char.arbitraryFromList (p : Nat) (chars : List Char) (pos : 0 < chars.length) :
     Arbitrary Char :=
   ⟨do
-    let x ← choose Nat 0 length (Nat.zero_le _)
+    let x ← choose Nat 0 p (Nat.zero_le _)
     if x.val == 0 then
       let n ← arbitrary
       pure <| Char.ofNat n
     else
       elements chars pos⟩
-
+/-- Pick a simple ASCII character 2/3s of the time, and otherwise pick any random `Char` encoded by
+    the next `Nat` (or `\0` if there is no such character)
+-/
 instance Char.arbitraryDefaultInstance : Arbitrary Char :=
   Char.arbitraryFromList 3 " 0123abcABC:,;`\\/".toList (by decide)
 

--- a/Plausible/Arbitrary.lean
+++ b/Plausible/Arbitrary.lean
@@ -69,67 +69,70 @@ instance Sum.Arbitrary [Arbitrary α] [Arbitrary β] : Arbitrary (Sum α β) whe
 
 instance Unit.Arbitrary : Arbitrary Unit := ⟨return ()⟩
 
-instance [Arbitrary α] [Arbitrary β] : Arbitrary ((_ : α) × β) where
+instance Sigma.Arbitrary [Arbitrary α] [Arbitrary β] : Arbitrary ((_ : α) × β) where
   arbitrary := do
     let p ← prodOf arbitrary arbitrary
     return ⟨p.fst, p.snd⟩
 
-instance Nat.Arbitrary : Arbitrary Nat := ⟨do choose Nat 0 (← getSize) (Nat.zero_le _)⟩
+instance Nat.Arbitrary : Arbitrary Nat where
+  arbitrary := do
+    choose Nat 0 (← getSize) (Nat.zero_le _)
 
-instance Fin.Arbitrary {n : Nat} : Arbitrary (Fin (n.succ)) :=
-  ⟨do
+instance Fin.Arbitrary {n : Nat} : Arbitrary (Fin (n.succ)) where
+  arbitrary := do
     let m ← choose Nat 0 (min (← getSize) n) (Nat.zero_le _)
-    return (Fin.ofNat _ m)⟩
+    return (Fin.ofNat _ m)
 
-instance BitVec.Arbitrary {n : Nat} : Arbitrary (BitVec n) :=
-  ⟨do
+instance BitVec.Arbitrary {n : Nat} : Arbitrary (BitVec n) where
+  arbitrary := do
     let m ← choose Nat 0 (min (← getSize) (2^n)) (Nat.zero_le _)
-    return BitVec.ofNat _ m⟩
+    return BitVec.ofNat _ m
 
-instance UInt8.Arbitrary : Arbitrary UInt8 :=
-  ⟨do
+instance UInt8.Arbitrary : Arbitrary UInt8 where
+  arbitrary := do
     let n ← choose Nat 0 (min (← getSize) UInt8.size) (Nat.zero_le _)
-    return UInt8.ofNat n⟩
+    return UInt8.ofNat n
 
-instance UInt16.Arbitrary : Arbitrary UInt16 :=
-  ⟨do
+instance UInt16.Arbitrary : Arbitrary UInt16 where
+  arbitrary := do
     let n ← choose Nat 0 (min (← getSize) UInt16.size) (Nat.zero_le _)
-    return UInt16.ofNat n⟩
+    return UInt16.ofNat n
 
-instance UInt32.Arbitrary : Arbitrary UInt32 :=
-  ⟨do
+instance UInt32.Arbitrary : Arbitrary UInt32 where
+  arbitrary := do
     let n ← choose Nat 0 (min (← getSize) UInt32.size) (Nat.zero_le _)
-    return UInt32.ofNat n⟩
+    return UInt32.ofNat n
 
-instance UInt64.Arbitrary : Arbitrary UInt64 :=
-  ⟨do
+instance UInt64.Arbitrary : Arbitrary UInt64 where
+  arbitrary := do
     let n ← choose Nat 0 (min (← getSize) UInt64.size) (Nat.zero_le _)
-    return UInt64.ofNat n⟩
+    return UInt64.ofNat n
 
-instance USize.Arbitrary : Arbitrary USize :=
-  ⟨do
+instance USize.Arbitrary : Arbitrary USize where
+  arbitrary := do
     let n ← choose Nat 0 (min (← getSize) USize.size) (Nat.zero_le _)
-    return USize.ofNat n⟩
+    return USize.ofNat n
 
-instance Int.Arbitrary : Arbitrary Int :=
-  ⟨do
-    choose Int (-(← getSize)) (← getSize) (by omega)⟩
+instance Int.Arbitrary : Arbitrary Int where
+  arbitrary := do
+    choose Int (-(← getSize)) (← getSize) (by omega)
 
-instance Bool.Arbitrary : Arbitrary Bool :=
-  ⟨chooseAny Bool⟩
+instance Bool.Arbitrary : Arbitrary Bool where
+  arbitrary := chooseAny Bool
 
 /-- This can be specialized into customized `Arbitrary Char` instances.
 The resulting instance has `1 / p` chances of making an unrestricted choice of characters
 and it otherwise chooses a character from `chars` with uniform probability. -/
 def Char.arbitraryFromList (p : Nat) (chars : List Char) (pos : 0 < chars.length) :
-    Arbitrary Char :=
-  ⟨do
+    Arbitrary Char where
+  arbitrary := do
     let x ← choose Nat 0 p (Nat.zero_le _)
     if x.val == 0 then
       let n ← arbitrary
       pure <| Char.ofNat n
     else
-      elements chars pos⟩
+      elements chars pos
+
 /-- Pick a simple ASCII character 2/3s of the time, and otherwise pick any random `Char` encoded by
     the next `Nat` (or `\0` if there is no such character)
 -/
@@ -152,8 +155,8 @@ instance List.Arbitrary [Arbitrary α] : Arbitrary (List α) where
 instance ULift.Arbitrary [Arbitrary α] : Arbitrary (ULift α) where
   arbitrary := do let x : α ← arbitrary; return ⟨x⟩
 
-instance String.Arbitrary : Arbitrary String :=
-  ⟨return String.mk (← Gen.listOf Char.arbitraryDefaultInstance.arbitrary)⟩
+instance String.Arbitrary : Arbitrary String where
+  arbitrary := return String.mk (← Gen.listOf arbitrary)
 
 instance Array.Arbitrary [Arbitrary α] : Arbitrary (Array α) := ⟨Gen.arrayOf arbitrary⟩
 

--- a/Plausible/Arbitrary.lean
+++ b/Plausible/Arbitrary.lean
@@ -20,7 +20,6 @@ whereas `Arbitrary` describes types which have a generator only.)
 ## Main definitions
 
 * `Arbitrary` typeclass
-* `ArbitraryFueled` typeclass
 
 ## References
 
@@ -134,8 +133,7 @@ def Char.arbitraryFromList (p : Nat) (chars : List Char) (pos : 0 < chars.length
       elements chars pos
 
 /-- Pick a simple ASCII character 2/3s of the time, and otherwise pick any random `Char` encoded by
-    the next `Nat` (or `\0` if there is no such character)
--/
+    the next `Nat` (or `\0` if there is no such character) -/
 instance Char.arbitraryDefaultInstance : Arbitrary Char :=
   Char.arbitraryFromList 3 " 0123abcABC:,;`\\/".toList (by decide)
 

--- a/Plausible/Arbitrary.lean
+++ b/Plausible/Arbitrary.lean
@@ -1,0 +1,159 @@
+/-
+Copyright (c) 2025 AWS. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: AWS
+-/
+import Plausible.Gen
+
+
+/-!
+# `Arbitrary` Typeclass
+
+The `Arbitrary` typeclass represents types for which there exists a
+random generator suitable for property-based testing, similar to
+Haskell QuickCheck's `Arbitrary` typeclass and Rocq/Coq QuickChick's `Gen` typeclass.
+
+(Note: the `Arbitrary` describes types which have *both* a generator & a shrinker,
+whereas `Arbitrary` describes types which have a generator only.)
+
+## Main definitions
+
+* `Arbitrary` typeclass
+* `ArbitraryFueled` typeclass
+
+## References
+
+* https://hackage.haskell.org/package/QuickCheck
+* https://softwarefoundations.cis.upenn.edu/qc-current/QuickChickInterface.html
+
+-/
+
+namespace Plausible
+
+open Gen
+
+universe u
+
+/-- The `Arbitrary` typeclass represents types for which there exists a
+    random generator suitable for property-based testing.
+    - This is the equivalent of Haskell QuickCheck's `Arbitrary` typeclass.
+    - In QuickChick, this typeclass is called `Gen`, but `Gen` is already
+    a reserved keyword in Plausible, so we call this typeclass `Arbitrary`
+    following the Haskell QuickCheck convention). -/
+class Arbitrary (α : Type u) where
+  /-- A random generator for values of the given type. -/
+  arbitrary : Gen α
+
+
+namespace Arbitrary
+
+/-- Samples from the generator associated with the `Arbitrary` instance for a type,
+    using `size` as the size parameter for the generator.
+    To invoke this function, you will need to specify what type `α` is,
+    for example by doing `runArbitrary (α := Nat) 10`. -/
+def runArbitrary [Arbitrary α] (size : Nat) : IO α :=
+  Gen.run Arbitrary.arbitrary size
+
+end Arbitrary
+
+section Instances
+
+open Arbitrary
+
+instance Sum.Arbitrary [Arbitrary α] [Arbitrary β] : Arbitrary (Sum α β) where
+  arbitrary := do
+    match ← chooseAny Bool with
+    | true => return .inl (← arbitrary)
+    | false => return .inr (← arbitrary)
+
+instance Unit.Arbitrary : Arbitrary Unit := ⟨return ()⟩
+
+instance [Arbitrary α] [Arbitrary β] : Arbitrary ((_ : α) × β) where
+  arbitrary := do
+    let p ← prodOf arbitrary arbitrary
+    return ⟨p.fst, p.snd⟩
+
+instance Nat.Arbitrary : Arbitrary Nat := ⟨do choose Nat 0 (← getSize) (Nat.zero_le _)⟩
+
+instance Fin.Arbitrary {n : Nat} : Arbitrary (Fin (n.succ)) :=
+  ⟨do
+    let m ← choose Nat 0 (min (← getSize) n) (Nat.zero_le _)
+    return (Fin.ofNat _ m)⟩
+
+instance BitVec.Arbitrary {n : Nat} : Arbitrary (BitVec n) :=
+  ⟨do
+    let m ← choose Nat 0 (min (← getSize) (2^n)) (Nat.zero_le _)
+    return BitVec.ofNat _ m⟩
+
+instance UInt8.Arbitrary : Arbitrary UInt8 :=
+  ⟨do
+    let n ← choose Nat 0 (min (← getSize) UInt8.size) (Nat.zero_le _)
+    return UInt8.ofNat n⟩
+
+instance UInt16.Arbitrary : Arbitrary UInt16 :=
+  ⟨do
+    let n ← choose Nat 0 (min (← getSize) UInt16.size) (Nat.zero_le _)
+    return UInt16.ofNat n⟩
+
+instance UInt32.Arbitrary : Arbitrary UInt32 :=
+  ⟨do
+    let n ← choose Nat 0 (min (← getSize) UInt32.size) (Nat.zero_le _)
+    return UInt32.ofNat n⟩
+
+instance UInt64.Arbitrary : Arbitrary UInt64 :=
+  ⟨do
+    let n ← choose Nat 0 (min (← getSize) UInt64.size) (Nat.zero_le _)
+    return UInt64.ofNat n⟩
+
+instance USize.Arbitrary : Arbitrary USize :=
+  ⟨do
+    let n ← choose Nat 0 (min (← getSize) USize.size) (Nat.zero_le _)
+    return USize.ofNat n⟩
+
+instance Int.Arbitrary : Arbitrary Int :=
+  ⟨do
+    choose Int (-(← getSize)) (← getSize) (by omega)⟩
+
+instance Bool.Arbitrary : Arbitrary Bool :=
+  ⟨chooseAny Bool⟩
+
+/-- This can be specialized into customized `Arbitrary Char` instances.
+The resulting instance has `1 / length` chances of making an unrestricted choice of characters
+and it otherwise chooses a character from `chars` with uniform probabilities. -/
+def Char.arbitraryFromList (length : Nat) (chars : List Char) (pos : 0 < chars.length) :
+    Arbitrary Char :=
+  ⟨do
+    let x ← choose Nat 0 length (Nat.zero_le _)
+    if x.val == 0 then
+      let n ← arbitrary
+      pure <| Char.ofNat n
+    else
+      elements chars pos⟩
+
+instance Char.arbitraryDefaultInstance : Arbitrary Char :=
+  Char.arbitraryFromList 3 " 0123abcABC:,;`\\/".toList (by decide)
+
+instance Option.Arbitrary [Arbitrary α] : Arbitrary (Option α) where
+  arbitrary := do
+    match ← chooseAny Bool with
+    | true => return none
+    | false => return some (← arbitrary)
+
+instance Prod.Arbitrary {α : Type u} {β : Type v} [Arbitrary α] [Arbitrary β] :
+    Arbitrary (α × β) where
+  arbitrary := prodOf arbitrary arbitrary
+
+instance List.Arbitrary [Arbitrary α] : Arbitrary (List α) where
+  arbitrary := Gen.listOf arbitrary
+
+instance ULift.Arbitrary [Arbitrary α] : Arbitrary (ULift α) where
+  arbitrary := do let x : α ← arbitrary; return ⟨x⟩
+
+instance String.Arbitrary : Arbitrary String :=
+  ⟨return String.mk (← Gen.listOf Char.arbitraryDefaultInstance.arbitrary)⟩
+
+instance Array.Arbitrary [Arbitrary α] : Arbitrary (Array α) := ⟨Gen.arrayOf arbitrary⟩
+
+end Instances
+
+end Plausible

--- a/Plausible/Functions.lean
+++ b/Plausible/Functions.lean
@@ -129,11 +129,11 @@ variable [Repr α]
 instance Pi.sampleableExt : SampleableExt (α → β) where
   proxy := TotalFunction α (SampleableExt.proxy β)
   interp f := SampleableExt.interp ∘ f.apply
-  sample := do
-    let xs : List (_ × _) ← (SampleableExt.sample (α := List (α × β)))
-    let ⟨x⟩ ← Gen.up <| (SampleableExt.sample : Gen (SampleableExt.proxy β))
+  sample := ⟨do
+    let xs : List (_ × _) ← (Arbitrary.arbitrary (α := List (SampleableExt.proxy α × SampleableExt.proxy β)))
+    let ⟨x⟩ ← Gen.up <| (Arbitrary.arbitrary : Gen (SampleableExt.proxy β))
     pure <| TotalFunction.withDefault (List.toFinmap' <| xs.map <|
-      Prod.map SampleableExt.interp id) x
+      Prod.map SampleableExt.interp id) x⟩
   -- note: no way of shrinking the domain without an inverse to `interp`
   shrink := { shrink := letI : Shrinkable α := {}; TotalFunction.shrink }
 

--- a/Plausible/Gen.lean
+++ b/Plausible/Gen.lean
@@ -36,10 +36,14 @@ instance instMonadLiftGen [MonadLift m (ReaderT (ULift Nat) (OptionT Id))] : Mon
 
 -- We get the wrong instance by default
 instance instMonadReaderGen : MonadReader (ULift Nat) Gen where
-  read := λ g ↦
+  read g :=
   do
     let size ← read
     return ⟨size, g⟩
+
+-- We get the wrong instance by default
+instance instMonadWithReaderGen : MonadWithReader (ULift Nat) Gen where
+  withReader f g := withReader f g
 
 instance instMonadErrorGen : MonadExcept Unit Gen := by infer_instance
 

--- a/Plausible/Sampleable.lean
+++ b/Plausible/Sampleable.lean
@@ -390,18 +390,11 @@ end NoShrink
 /--
 Print (at most) 10 samples of a given type to stdout for debugging.
 -/
-def printSamples {t : Type u} [Repr t] (g : Gen t) : IO PUnit := do
--- TODO: this should be a global instance
-  letI : MonadLift Id IO := ⟨fun f => pure <| Id.run f⟩
-  do
-    -- we can't convert directly from `Rand (List t)` to `RandT IO (List Std.Format)`
-    -- (and `RandT IO (List t)` isn't type-correct without
-    -- https://github.com/leanprover/lean4/issues/3011), so go via an intermediate
-    let xs : List Std.Format ← Plausible.runRand <| Rand.down <| do
-      let xs : List t ← (List.range 10).mapM (ReaderT.run g ∘ ULift.up)
-      pure <| ULift.up (xs.map repr)
-    for x in xs do
-      IO.println s!"{x}"
+def printSamples {t : Type} [Repr t] (g : Gen t) : IO PUnit := do
+  let xs ← (List.range 10).mapM (Gen.run g)
+  let xs := xs.map repr
+  for x in xs do
+    IO.println s!"{x}"
 
 open Lean Meta Elab
 

--- a/Plausible/Sampleable.lean
+++ b/Plausible/Sampleable.lean
@@ -6,6 +6,7 @@ Authors: Henrik Böving, Simon Hudon
 import Lean.Elab.Command
 import Lean.Meta.Eval
 import Plausible.Gen
+import Plausible.Arbitrary
 
 /-!
 # `SampleableExt` Class
@@ -38,8 +39,8 @@ the test passes and `Plausible` moves on to trying more examples.
 
 `SampleableExt` can be used in two ways. The first (and most common)
 is to simply generate values of a type directly using the `Gen` monad,
-if this is what you want to do then `SampleableExt.mkSelfContained` is
-the way to go.
+if this is what you want to do then the way to go is to declare an `Arbitrary`
+instance, and rely on the default `selfContained` instance.
 
 Furthermore it makes it possible to express generators for types that
 do not lend themselves to introspection, such as `Nat → Nat`.
@@ -96,8 +97,8 @@ class Shrinkable (α : Type u) where
 
 /-- `SampleableExt` can be used in two ways. The first (and most common)
 is to simply generate values of a type directly using the `Gen` monad,
-if this is what you want to do then `SampleableExt.mkSelfContained` is
-the way to go.
+if this is what you want to do then declaring an `Arbitrary` instance is the
+way to go.
 
 Furthermore it makes it possible to express generators for types that
 do not lend themselves to introspection, such as `Nat → Nat`.
@@ -110,7 +111,7 @@ class SampleableExt (α : Sort u) where
   proxy : Type v
   [proxyRepr : Repr proxy]
   [shrink : Shrinkable proxy]
-  sample : Gen proxy
+  [sample : Arbitrary proxy]
   interp : proxy → α
 
 attribute [instance] SampleableExt.proxyRepr
@@ -118,19 +119,20 @@ attribute [instance] SampleableExt.shrink
 
 namespace SampleableExt
 
-/-- Use to generate instance whose purpose is to simply generate values
+/-- Default instance whose purpose is to simply generate values
 of a type directly using the `Gen` monad -/
-def mkSelfContained [Repr α] [Shrinkable α] (sample : Gen α) : SampleableExt α where
+@[default_instance]
+instance selfContained [Repr α] [Shrinkable α] [Arbitrary α] : SampleableExt α where
   proxy := α
   proxyRepr := inferInstance
   shrink := inferInstance
-  sample := sample
+  sample := inferInstance
   interp := id
 
 /-- First samples a proxy value and interprets it. Especially useful if
 the proxy and target type are the same. -/
 def interpSample (α : Type u) [SampleableExt α] : Gen α :=
-  SampleableExt.interp <$> SampleableExt.sample
+  SampleableExt.interp <$> SampleableExt.sample.arbitrary
 
 end SampleableExt
 
@@ -242,95 +244,26 @@ end Shrinkers
 section Samplers
 
 open SampleableExt
+open Arbitrary
+
+instance arbitraryProxy [SampleableExt α] : Arbitrary (proxy α) := sample
 
 instance Sum.SampleableExt [SampleableExt α] [SampleableExt β] : SampleableExt (Sum α β) where
   proxy := Sum (proxy α) (proxy β)
-  sample := do
-    match ← chooseAny Bool with
-    | true => return .inl (← sample)
-    | false => return .inr (← sample)
+  sample := inferInstance
   interp s :=
     match s with
     | .inl l => .inl (interp l)
     | .inr r => .inr (interp r)
 
-instance Unit.sampleableExt : SampleableExt Unit :=
-  mkSelfContained (return ())
-
 instance [SampleableExt α] [SampleableExt β] : SampleableExt ((_ : α) × β) where
   proxy := (_ : proxy α) × proxy β
-  sample := do
-    let p ← prodOf sample sample
-    return ⟨p.fst, p.snd⟩
+  sample := inferInstance
   interp s := ⟨interp s.fst, interp s.snd⟩
-
-instance Nat.sampleableExt : SampleableExt Nat :=
-  mkSelfContained (do choose Nat 0 (← getSize) (Nat.zero_le _))
-
-instance Fin.sampleableExt {n : Nat} : SampleableExt (Fin (n.succ)) :=
-  mkSelfContained do
-    let m ← choose Nat 0 (min (← getSize) n) (Nat.zero_le _)
-    return (Fin.ofNat _ m)
-
-instance BitVec.sampleableExt {n : Nat} : SampleableExt (BitVec n) :=
-  mkSelfContained do
-    let m ← choose Nat 0 (min (← getSize) (2^n)) (Nat.zero_le _)
-    return BitVec.ofNat _ m
-
-instance UInt8.SampleableExt : SampleableExt UInt8 :=
-  mkSelfContained do
-    let n ← choose Nat 0 (min (← getSize) UInt8.size) (Nat.zero_le _)
-    return UInt8.ofNat n
-
-instance UInt16.SampleableExt : SampleableExt UInt16 :=
-  mkSelfContained do
-    let n ← choose Nat 0 (min (← getSize) UInt16.size) (Nat.zero_le _)
-    return UInt16.ofNat n
-
-instance UInt32.SampleableExt : SampleableExt UInt32 :=
-  mkSelfContained do
-    let n ← choose Nat 0 (min (← getSize) UInt32.size) (Nat.zero_le _)
-    return UInt32.ofNat n
-
-instance UInt64.SampleableExt : SampleableExt UInt64 :=
-  mkSelfContained do
-    let n ← choose Nat 0 (min (← getSize) UInt64.size) (Nat.zero_le _)
-    return UInt64.ofNat n
-
-instance USize.SampleableExt : SampleableExt USize :=
-  mkSelfContained do
-    let n ← choose Nat 0 (min (← getSize) USize.size) (Nat.zero_le _)
-    return USize.ofNat n
-
-instance Int.sampleableExt : SampleableExt Int :=
-  mkSelfContained do
-    choose Int (-(← getSize)) (← getSize) (by omega)
-
-instance Bool.sampleableExt : SampleableExt Bool :=
-  mkSelfContained <| chooseAny Bool
-
-/-- This can be specialized into customized `SampleableExt Char` instances.
-The resulting instance has `1 / length` chances of making an unrestricted choice of characters
-and it otherwise chooses a character from `chars` with uniform probabilities. -/
-def Char.sampleable (length : Nat) (chars : List Char) (pos : 0 < chars.length) :
-    SampleableExt Char :=
-  mkSelfContained do
-    let x ← choose Nat 0 length (Nat.zero_le _)
-    if x.val == 0 then
-      let n ← interpSample Nat
-      pure <| Char.ofNat n
-    else
-      elements chars pos
-
-instance Char.sampleableDefault : SampleableExt Char :=
-  Char.sampleable 3 " 0123abcABC:,;`\\/".toList (by decide)
 
 instance Option.sampleableExt [SampleableExt α] : SampleableExt (Option α) where
   proxy := Option (proxy α)
-  sample := do
-    match ← chooseAny Bool with
-    | true => return none
-    | false => return some (← sample)
+  sample := inferInstance
   interp o := o.map interp
 
 instance Prod.sampleableExt {α : Type u} {β : Type v} [SampleableExt α] [SampleableExt β] :
@@ -338,19 +271,19 @@ instance Prod.sampleableExt {α : Type u} {β : Type v} [SampleableExt α] [Samp
   proxy := Prod (proxy α) (proxy β)
   proxyRepr := inferInstance
   shrink := inferInstance
-  sample := prodOf sample sample
+  sample := inferInstance
   interp := Prod.map interp interp
 
 instance Prop.sampleableExt : SampleableExt Prop where
   proxy := Bool
   proxyRepr := inferInstance
-  sample := interpSample Bool
+  sample := inferInstance
   shrink := inferInstance
   interp := Coe.coe
 
 instance List.sampleableExt [SampleableExt α] : SampleableExt (List α) where
   proxy := List (proxy α)
-  sample := Gen.listOf sample
+  sample := inferInstance
   interp := List.map interp
 
 instance ULift.sampleableExt [SampleableExt α] : SampleableExt (ULift α) where
@@ -358,12 +291,9 @@ instance ULift.sampleableExt [SampleableExt α] : SampleableExt (ULift α) where
   sample := sample
   interp a := ⟨interp a⟩
 
-instance String.sampleableExt : SampleableExt String :=
-  mkSelfContained do return String.mk (← Gen.listOf (Char.sampleableDefault.sample))
-
 instance Array.sampleableExt [SampleableExt α] : SampleableExt (Array α) where
   proxy := Array (proxy α)
-  sample := Gen.arrayOf sample
+  sample := inferInstance
   interp := Array.map interp
 
 end Samplers
@@ -372,6 +302,8 @@ end Samplers
 def NoShrink (α : Type u) := α
 
 namespace NoShrink
+
+open SampleableExt
 
 def mk (x : α) : NoShrink α := x
 def get (x : NoShrink α) : α := x
@@ -382,13 +314,16 @@ instance repr [inst : Repr α] : Repr (NoShrink α) := inst
 instance shrinkable : Shrinkable (NoShrink α) where
   shrink := fun _ => []
 
-instance sampleableExt [SampleableExt α] [Repr α] : SampleableExt (NoShrink α) :=
-  SampleableExt.mkSelfContained <| (NoShrink.mk ∘ SampleableExt.interp) <$> SampleableExt.sample
+instance arbitrary [arb : Arbitrary α] : Arbitrary (NoShrink α) := arb
+
+instance sampleableExt [SampleableExt α] [Repr α] : SampleableExt (NoShrink α) where
+  proxy := NoShrink (proxy α)
+  interp := interp
 
 end NoShrink
 
 /--
-Print (at most) 10 samples of a given type to stdout for debugging.
+Print (at most) 10 samples of a given type to stdout for debugging. Sadly specialized to `Type 0`
 -/
 def printSamples {t : Type} [Repr t] (g : Gen t) : IO PUnit := do
   let xs ← (List.range 10).mapM (Gen.run g)
@@ -419,7 +354,8 @@ private def mkGenerator (e : Expr) : MetaM (Level × Expr × Expr × Expr) := do
     let sampleableExtInst ← synthInstance (mkApp (mkConst ``SampleableExt [u, v]) e)
     let v ← instantiateLevelMVars v
     let reprInst := mkApp2 (mkConst ``SampleableExt.proxyRepr [u, v]) e sampleableExtInst
-    let gen := mkApp2 (mkConst ``SampleableExt.sample [u, v]) e sampleableExtInst
+    let arb := mkApp2 (mkConst ``SampleableExt.sample [u, v]) e sampleableExtInst
+    let gen := mkApp2 (mkConst ``Arbitrary.arbitrary [v]) e arb
     let typ := mkApp2 (mkConst ``SampleableExt.proxy [u, v]) e sampleableExtInst
     return ⟨v, typ, reprInst, gen⟩
 
@@ -460,8 +396,8 @@ values of type `type` using an increasing size parameter.
 elab "#sample " e:term : command =>
   Command.runTermElabM fun _ => do
     let e ← Elab.Term.elabTermAndSynthesize e none
-    let ⟨u, α, repr, gen⟩ ← mkGenerator e
-    let printSamples := mkApp3 (mkConst ``printSamples [u]) α repr gen
+    let ⟨_, α, repr, gen⟩ ← mkGenerator e
+    let printSamples := mkApp3 (mkConst ``printSamples []) α repr gen
     let code ← unsafe evalExpr (IO PUnit) (mkApp (mkConst ``IO) (mkConst ``PUnit [1])) printSamples
     _ ← code
 

--- a/Plausible/Sampleable.lean
+++ b/Plausible/Sampleable.lean
@@ -327,16 +327,6 @@ instance sampleableExt [SampleableExt α] [Repr α] : SampleableExt (NoShrink α
 
 end NoShrink
 
-/--
-Print (at most) 10 samples of a given type to stdout for debugging. Sadly specialized to `Type 0`
--/
-def printSamples {t : Type} [Repr t] (g : Gen t) : IO PUnit := do
-  let runIO (x : IOGen t) : IO t := x
-  let xs : List t ← (List.range 10).mapM (runIO ∘ Gen.run g)
-  let xs := xs.map repr
-  for x in xs do
-    IO.println s!"{x}"
-
 open Lean Meta Elab
 
 /--
@@ -403,7 +393,7 @@ elab "#sample " e:term : command =>
   Command.runTermElabM fun _ => do
     let e ← Elab.Term.elabTermAndSynthesize e none
     let ⟨_, α, repr, gen⟩ ← mkGenerator e
-    let printSamples := mkApp3 (mkConst ``printSamples []) α repr gen
+    let printSamples := mkApp3 (mkConst ``Gen.printSamples []) α repr gen
     let code ← unsafe evalExpr (IO PUnit) (mkApp (mkConst ``IO) (mkConst ``PUnit [1])) printSamples
     _ ← code
 

--- a/Plausible/Testable.lean
+++ b/Plausible/Testable.lean
@@ -538,7 +538,7 @@ def Testable.runSuiteAux (p : Prop) [Testable p] (cfg : Configuration) :
 def Testable.runSuite (p : Prop) [Testable p] (cfg : Configuration := {}) : Gen (TestResult p) :=
   Testable.runSuiteAux p cfg (success <| PSum.inl ()) cfg.numInst
 
-/-- Run a test suite for `p` in `BaseIO` using the global RNG in `stdGenRef`. -/
+/-- Run a test suite for `p` in `IO` using the global RNG in `stdGenRef`. -/
 def Testable.checkIO (p : Prop) [Testable p] (cfg : Configuration := {}) : IO (TestResult p) :=
   match cfg.randomSeed with
   | none => Gen.run (Testable.runSuite p cfg) 0

--- a/Plausible/Testable.lean
+++ b/Plausible/Testable.lean
@@ -388,7 +388,7 @@ bound variable with it. -/
 instance varTestable [SampleableExt α] {β : α → Prop} [∀ x, Testable (β x)] :
     Testable (NamedBinder var <| ∀ x : α, β x) where
   run := fun cfg min => do
-    let x ← SampleableExt.sample
+    let x ← Arbitrary.arbitrary
     if cfg.traceSuccesses || cfg.traceDiscarded then
       slimTrace s!"{var} := {repr x}"
     let r ← Testable.runProp (β <| SampleableExt.interp x) cfg false
@@ -421,7 +421,8 @@ where
     let finalR := addInfo s!"{var} is irrelevant (unused)" id r
     return imp (· <| Classical.ofNonempty) finalR (PSum.inr <| fun x _ => x)
 
-instance (priority := 2000) subtypeVarTestable {p : α → Prop} {β : α → Prop}
+universe u in
+instance (priority := 2000) subtypeVarTestable {α : Type u} {p : α → Prop} {β : α → Prop}
     [∀ x, PrintableProp (p x)]
     [∀ x, Testable (β x)]
     [SampleableExt (Subtype p)] {var'} :

--- a/Test/Testable.lean
+++ b/Test/Testable.lean
@@ -18,11 +18,11 @@ instance : Shrinkable MyType where
     let proxy := Shrinkable.shrink (x, y - x)
     proxy.map (fun (fst, snd) => ⟨fst, fst + snd, by omega⟩)
 
-instance : SampleableExt MyType :=
-  SampleableExt.mkSelfContained do
+instance : Arbitrary MyType :=
+  ⟨do
     let x ← SampleableExt.interpSample Nat
     let xyDiff ← SampleableExt.interpSample Nat
-    return ⟨x, x + xyDiff, by omega⟩
+    return ⟨x, x + xyDiff, by omega⟩⟩
 
 -- TODO: this is a noisy test.
 -- We can't use `#guard_msgs` because the number of attempts to non-deterministic.


### PR DESCRIPTION
This change is a proposal to facilitate further changes, including the one made in PR #35 . It includes 3 main changes:

- Change the definition of `Gen` from `ReaderT (ULift Nat) Random` to `RandT (ReaderT (ULift Nat) (OptionT Id))`. This uses the `RandT` transformer as intended, rather than throwing away it's state, and should make further additions to the `Gen` state easier.
- Add an `Arbitrary` class as a wrapper for `Gen`. This is for convenience, as it avoids having to think about `proxy` and `Shrinkable`s.
- Allow for generation failure (the `OptionT Id` bit of `Gen`). This makes it so that, e.g. an `Arbitrary (Subtype p)` can do bounded proof search and give up if needed, which should make it easier to build such instances.

Happy to hear thoughts.