### PR TITLE
feat: Derive Arbitrary instances for inductive datatypes.

### DIFF
--- a/Plausible.lean
+++ b/Plausible.lean
@@ -10,3 +10,5 @@ import Plausible.Testable
 import Plausible.Functions
 import Plausible.Attr
 import Plausible.Tactic
+import Plausible.Arbitrary
+import Plausible.DeriveArbitrary

--- a/Plausible/ArbitraryFueled.lean
+++ b/Plausible/ArbitraryFueled.lean
@@ -1,0 +1,32 @@
+/-
+Copyright (c) 2025 AWS. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: AWS
+-/
+import Plausible.Arbitrary
+import Plausible.Gen
+
+namespace Plausible
+
+open Gen
+
+/-- A typeclass for *fueled* random generation, i.e. a variant of
+    the `Arbitrary` typeclass where the fuel for the generator is made explicit.
+    - This typeclass is equivalent to Rocq QuickChick's `arbitrarySized` typeclass
+      (QuickChick uses the `Nat` parameter as both fuel and the generator size,
+       here we use it just for fuel, as Plausible's `Gen` type constructor
+       already internalizes the size parameter.) -/
+class ArbitraryFueled (α : Type) where
+  /-- Takes a `Nat` and produces a random generator dependent on the `Nat` parameter
+      (which indicates the amount of fuel to be used before failing). -/
+  arbitraryFueled : Nat → Gen α
+
+/-- Every `ArbitraryFueled` instance gives rise to an `Arbitrary` instance -/
+instance [ArbitraryFueled α] : Arbitrary α where
+  arbitrary := Gen.sized ArbitraryFueled.arbitraryFueled
+
+/-- Raised when a fueled generator fails due to insufficient fuel. -/
+def Gen.outOfFuel : GenError :=
+  .genError "out of fuel"
+
+end Plausible

--- a/Plausible/Attr.lean
+++ b/Plausible/Attr.lean
@@ -13,3 +13,4 @@ initialize registerTraceClass `plausible.discarded
 initialize registerTraceClass `plausible.success
 initialize registerTraceClass `plausible.shrink.steps
 initialize registerTraceClass `plausible.shrink.candidates
+initialize registerTraceClass `plausible.deriving.arbitrary

--- a/Plausible/Gen.lean
+++ b/Plausible/Gen.lean
@@ -29,11 +29,13 @@ open Random
 /-- Error thrown on generation failure, e.g. because you've run out of resources. -/
 inductive GenError : Type where
 | genError : String → GenError
-deriving Inhabited
+deriving Inhabited, Repr, BEq
+
+def Gen.genericFailure : GenError := .genError "Generation failure."
 
 /-- Monad to generate random examples to test properties with.
 It has a `Nat` parameter so that the caller can decide on the
-size of the examples. It allows failure to generate via the `ExceptT` transformer -/
+size of the examples. It allows failure to generate via the `Except` monad -/
 abbrev Gen (α : Type u) := RandT (ReaderT (ULift Nat) (Except GenError)) α
 
 instance instMonadLiftGen [MonadLiftT m (ReaderT (ULift Nat) (Except GenError))] : MonadLiftT (RandGT StdGen m) Gen where
@@ -91,6 +93,52 @@ Choose a `Nat` between `0` and `getSize`.
 -/
 def chooseNat : Gen Nat := do choose Nat 0 (← getSize) (by omega)
 
+/-!
+The following section defines various combinators for generators, which are used
+in the body of derived generators (for derived `Arbitrary` instances).
+
+The code for these combinators closely mirrors those used in Rocq/Coq QuickChick
+(see link in the **References** section below).
+
+## References
+* https://github.com/QuickChick/QuickChick/blob/master/src/Generators.v
+
+-/
+
+/-- `pick default xs n` chooses a weight & a generator `(k, gen)` from the list `xs` such that `n < k`.
+    If `xs` is empty, the `default` generator with weight 0 is returned.  -/
+private def pick (default : Gen α) (xs : List (Nat × Gen α)) (n : Nat) : Nat × Gen α :=
+  match xs with
+  | [] => (0, default)
+  | (k, x) :: xs =>
+    if n < k then
+      (k, x)
+    else
+      pick default xs (n - k)
+
+/-- Picks one of the generators in `gs` at random, returning the `default` generator
+    if `gs` is empty.
+
+    (This is a more ergonomic version of Plausible's `Gen.oneOf` which doesn't
+    require the caller to supply a proof that the list index is in bounds.) -/
+def oneOfWithDefault (default : Gen α) (gs : List (Gen α)) : Gen α :=
+  match gs with
+  | [] => default
+  | _ => do
+    let idx ← Gen.choose Nat 0 (gs.length - 1) (by omega)
+    List.getD gs idx.val default
+
+/-- `frequency` picks a generator from the list `gs` according to the weights in `gs`.
+    If `gs` is empty, the `default` generator is returned.  -/
+def frequency (default : Gen α) (gs : List (Nat × Gen α)) : Gen α := do
+  let total := List.sum <| List.map Prod.fst gs
+  let n ← Gen.choose Nat 0 (total - 1) (by omega)
+  (pick default gs n).snd
+
+/-- `sized f` constructs a generator that depends on its `size` parameter -/
+def sized (f : Nat → Gen α) : Gen α :=
+  Gen.getSize >>= f
+
 variable {α : Type u}
 
 /-- Create an `Array` of examples using `x`. The size is controlled
@@ -135,7 +183,7 @@ def prodOf {α : Type u} {β : Type v} (x : Gen α) (y : Gen β) : Gen (α × β
 
 end Gen
 
-private def errorOfGenError {α} (m : ExceptT GenError Id α) : IO α :=
+private def errorOfGenError {α} (m : Except GenError α) : IO α :=
   match m with
   | .ok a => pure a
   | .error (.genError msg) => throw <| .userError ("Generation failure:" ++ msg)
@@ -153,10 +201,14 @@ def Gen.run {α : Type} (x : Gen α) (size : Nat) : IO α :=
 Print (at most) 10 samples of a given type to stdout for debugging. Sadly specialized to `Type 0`
 -/
 def Gen.printSamples {t : Type} [Repr t] (g : Gen t) : IO PUnit := do
-  let xs : List t ← (List.range 10).mapM (Gen.run g)
-  let xs := xs.map repr
+  let xs := List.range 10
   for x in xs do
-    IO.println s!"{x}"
+    try
+      let y ← Gen.run g x
+      IO.println s!"{repr y}"
+    catch
+      | .userError msg => IO.println msg
+      | e => throw e
 
 /-- Execute a `Gen` until it actually produces an output. May diverge for bad generators! -/
 partial def Gen.runUntil {α : Type} (attempts : Option Nat := .none) (x : Gen α) (size : Nat) : IO α :=
@@ -174,8 +226,7 @@ partial def Gen.runUntil {α : Type} (attempts : Option Nat := .none) (x : Gen �
   | .some n => .some (n-1)
   | .none => .none
 
-
-def test : Gen Nat :=
+private def test : Gen Nat :=
   do
     let x : Nat ← Gen.choose Nat 0 (← Gen.getSize) (Nat.zero_le _)
     if x % 10 == 0

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ example (xs ys : Array Nat) : xs.size = ys.size → xs = ys := by
 ```
 
 If you are defining your own type it needs instances of `Repr`, `Plausible.Shrinkable` and
-`Plausible.SampleableExt`:
+`Plausible.SampleableExt` (or `Plausible.Arbitrary`):
 ```lean
 import Plausible
 
@@ -50,3 +50,14 @@ instance : SampleableExt MyType :=
 #eval Testable.check <| ∀ a b : MyType, a.y ≤ b.x → a.x ≤ b.y
 ```
 For more documentation refer to the module docs.
+
+**Deriving Instance for `Arbitrary`** (for algebraic data types)              
+Users can write `deriving Arbitrary` after an inductive type definition, i.e.
+```lean 
+inductive Foo where
+  ...
+  deriving Arbitrary
+```
+
+Alternatively, users can also write `deriving instance Arbitrary for T1, ..., Tn` as a top-level command to derive `Arbitrary` instances for types `T1, ..., Tn` simultaneously.
+

--- a/Test.lean
+++ b/Test.lean
@@ -5,3 +5,15 @@ Authors: Henrik Böving
 -/
 import Test.Tactic
 import Test.Testable
+
+-- Tests for `deriving Arbitrary`
+import Test.DeriveArbitrary.DeriveTreeGenerator
+import Test.DeriveArbitrary.DeriveSTLCTermTypeGenerators
+import Test.DeriveArbitrary.DeriveNKIValueGenerator
+import Test.DeriveArbitrary.DeriveNKIBinopGenerator
+import Test.DeriveArbitrary.DeriveRegExpGenerator
+import Test.DeriveArbitrary.StructureTest
+import Test.DeriveArbitrary.BitVecStructureTest
+import Test.DeriveArbitrary.MissingNonRecursiveConstructorTest
+import Test.DeriveArbitrary.ParameterizedTypeTest
+import Test.DeriveArbitrary.MutuallyRecursiveTypeTest

--- a/Test/DeriveArbitrary/BitVecStructureTest.lean
+++ b/Test/DeriveArbitrary/BitVecStructureTest.lean
@@ -1,0 +1,92 @@
+import Plausible.Arbitrary
+import Plausible.DeriveArbitrary
+import Plausible.Attr
+import Plausible.Testable
+
+open Plausible Gen
+
+set_option guard_msgs.diff true
+
+/-- Dummy `inductive` where a constructor has a dependently-typed argument (`BitVec n`)
+    whose index does not appear in the overall type (`DummyInductive`) -/
+inductive DummyInductive where
+  | FromBitVec : ∀ (n : Nat), BitVec n → String → DummyInductive
+  deriving Repr
+
+set_option trace.plausible.deriving.arbitrary true in
+/--
+trace: [plausible.deriving.arbitrary] ⏎
+    [mutual
+       def instArbitraryDummyInductive.arbitrary : Nat → Plausible.Gen (@DummyInductive✝) :=
+         let rec aux_arb (fuel✝ : Nat) : Plausible.Gen (@DummyInductive✝) :=
+           (match fuel✝ with
+           | Nat.zero =>
+             Plausible.Gen.oneOfWithDefault
+               (do
+                 let a✝ ← Plausible.Arbitrary.arbitrary
+                 let a✝¹ ← Plausible.Arbitrary.arbitrary
+                 let a✝² ← Plausible.Arbitrary.arbitrary
+                 return DummyInductive.FromBitVec a✝ a✝¹ a✝²)
+               [(do
+                   let a✝ ← Plausible.Arbitrary.arbitrary
+                   let a✝¹ ← Plausible.Arbitrary.arbitrary
+                   let a✝² ← Plausible.Arbitrary.arbitrary
+                   return DummyInductive.FromBitVec a✝ a✝¹ a✝²)]
+           | fuel'✝ + 1 =>
+             Plausible.Gen.frequency
+               (do
+                 let a✝ ← Plausible.Arbitrary.arbitrary
+                 let a✝¹ ← Plausible.Arbitrary.arbitrary
+                 let a✝² ← Plausible.Arbitrary.arbitrary
+                 return DummyInductive.FromBitVec a✝ a✝¹ a✝²)
+               [(1,
+                   (do
+                     let a✝ ← Plausible.Arbitrary.arbitrary
+                     let a✝¹ ← Plausible.Arbitrary.arbitrary
+                     let a✝² ← Plausible.Arbitrary.arbitrary
+                     return DummyInductive.FromBitVec a✝ a✝¹ a✝²)),
+                 ])
+         fun fuel✝ => aux_arb fuel✝
+     end,
+     instance : Plausible.ArbitraryFueled✝ (@DummyInductive✝) :=
+       ⟨instArbitraryDummyInductive.arbitrary⟩]
+-/
+#guard_msgs in
+deriving instance Arbitrary for DummyInductive
+
+-- Test that we can successfully synthesize instances of `Arbitrary` & `ArbitraryFueled`
+
+/-- info: instArbitraryFueledDummyInductive -/
+#guard_msgs in
+#synth ArbitraryFueled DummyInductive
+
+/-- info: instArbitraryOfArbitraryFueled -/
+#guard_msgs in
+#synth Arbitrary DummyInductive
+
+/-- Shrinker for `DummyInductive` -/
+def shrinkDummyInductive : DummyInductive → List DummyInductive
+  | .FromBitVec n bitVec str =>
+    let shrunkenBitVecs := Shrinkable.shrink bitVec
+    let shrunkenStrs := Shrinkable.shrink str
+    (fun (bv, s) => .FromBitVec n bv s) <$> List.zip shrunkenBitVecs shrunkenStrs
+
+/-- `Shrinkable` instance for `DummyInductive` -/
+instance : Shrinkable DummyInductive where
+  shrink := shrinkDummyInductive
+
+/-- `SampleableExt` instance for `DummyInductive` -/
+instance : SampleableExt DummyInductive :=
+  SampleableExt.mkSelfContained Arbitrary.arbitrary
+
+/-- To test whether the derived generator can generate counterexamples,
+    we state an (erroneous) property that states that all `BitVec` arguments
+    to `DummyInductive.FromBitVec` represent the `Nat` 2, and see
+    if the derived generator can refute this property. -/
+def BitVecEqualsTwo : DummyInductive → Bool
+  | .FromBitVec _ bitVec _ => bitVec.toNat == 2
+
+/-- error: Found a counter-example! -/
+#guard_msgs in
+#eval Testable.check (∀ ind : DummyInductive, BitVecEqualsTwo ind)
+  (cfg := {numInst := 10, maxSize := 5, quiet := true})

--- a/Test/DeriveArbitrary/DeriveNKIBinopGenerator.lean
+++ b/Test/DeriveArbitrary/DeriveNKIBinopGenerator.lean
@@ -1,0 +1,82 @@
+import Plausible.Attr
+import Plausible.Arbitrary
+import Plausible.DeriveArbitrary
+import Plausible.Testable
+
+open Plausible Gen
+
+set_option guard_msgs.diff true
+
+/-- Binary operators for the NKI language,
+    adapted from https://github.com/leanprover/KLR/blob/main/KLR/NKI/Basic.lean -/
+inductive BinOp where
+  -- logical
+  | land | lor
+  -- comparison
+  | eq | ne | lt | le | gt | ge
+  -- arithmetic
+  | add | sub | mul | div | mod | pow | floor
+  -- bitwise
+  | lshift | rshift | or | xor | and
+  deriving Repr
+
+set_option trace.plausible.deriving.arbitrary true in
+/--
+trace: [plausible.deriving.arbitrary] ⏎
+    [mutual
+       def instArbitraryBinOp.arbitrary : Nat → Plausible.Gen (@BinOp✝) :=
+         let rec aux_arb (fuel✝ : Nat) : Plausible.Gen (@BinOp✝) :=
+           (match fuel✝ with
+           | Nat.zero =>
+             Plausible.Gen.oneOfWithDefault (pure BinOp.land)
+               [(pure BinOp.land), (pure BinOp.lor), (pure BinOp.eq), (pure BinOp.ne), (pure BinOp.lt), (pure BinOp.le),
+                 (pure BinOp.gt), (pure BinOp.ge), (pure BinOp.add), (pure BinOp.sub), (pure BinOp.mul),
+                 (pure BinOp.div), (pure BinOp.mod), (pure BinOp.pow), (pure BinOp.floor), (pure BinOp.lshift),
+                 (pure BinOp.rshift), (pure BinOp.or), (pure BinOp.xor), (pure BinOp.and)]
+           | fuel'✝ + 1 =>
+             Plausible.Gen.frequency (pure BinOp.land)
+               [(1, (pure BinOp.land)), (1, (pure BinOp.lor)), (1, (pure BinOp.eq)), (1, (pure BinOp.ne)),
+                 (1, (pure BinOp.lt)), (1, (pure BinOp.le)), (1, (pure BinOp.gt)), (1, (pure BinOp.ge)),
+                 (1, (pure BinOp.add)), (1, (pure BinOp.sub)), (1, (pure BinOp.mul)), (1, (pure BinOp.div)),
+                 (1, (pure BinOp.mod)), (1, (pure BinOp.pow)), (1, (pure BinOp.floor)), (1, (pure BinOp.lshift)),
+                 (1, (pure BinOp.rshift)), (1, (pure BinOp.or)), (1, (pure BinOp.xor)), (1, (pure BinOp.and)), ])
+         fun fuel✝ => aux_arb fuel✝
+     end,
+     instance : Plausible.ArbitraryFueled✝ (@BinOp✝) :=
+       ⟨instArbitraryBinOp.arbitrary⟩]
+-/
+#guard_msgs in
+deriving instance Arbitrary for BinOp
+
+-- Test that we can successfully synthesize instances of `Arbitrary` & `ArbitraryFueled`
+
+/-- info: instArbitraryFueledBinOp -/
+#guard_msgs in
+#synth ArbitraryFueled BinOp
+
+/-- info: instArbitraryOfArbitraryFueled -/
+#guard_msgs in
+#synth Arbitrary BinOp
+
+/-- Trivial `Shrinkable` instance for `BinOp`s -/
+instance : Shrinkable BinOp where
+  shrink := fun _ => []
+
+/-- `SampleableExt` instance for `BinOp` -/
+instance : SampleableExt BinOp :=
+  SampleableExt.mkSelfContained Arbitrary.arbitrary
+
+-- To test whether the derived generator can generate counterexamples,
+-- we state an (erroneous) property that states that all binary operators
+-- are logical operators, and see if the generator can refute this property.
+
+/-- Determines whether a `BinOp` is a logical operation -/
+def isLogicalOp (op : BinOp) : Bool :=
+  match op with
+  | .land | .lor => true
+  | _ => false
+
+/-- error: Found a counter-example! -/
+#guard_msgs in
+#eval Testable.check (∀ op : BinOp, isLogicalOp op)
+  (cfg := {numInst := 10, maxSize := 5, quiet := true})

--- a/Test/DeriveArbitrary/DeriveNKIValueGenerator.lean
+++ b/Test/DeriveArbitrary/DeriveNKIValueGenerator.lean
@@ -1,0 +1,116 @@
+import Plausible.Arbitrary
+import Plausible.DeriveArbitrary
+import Plausible.Attr
+import Plausible.Testable
+
+open Plausible Gen
+
+set_option guard_msgs.diff true
+
+/-- A datatype representing values in the NKI language, adapted from
+    https://github.com/leanprover/KLR/blob/main/KLR/NKI/Basic.lean -/
+inductive Value where
+  | none
+  | bool (value : Bool)
+  | int (value : Int)
+  | string (value : String)
+  | ellipsis
+  | tensor (shape : List Nat) (dtype : String)
+  deriving Repr
+
+set_option trace.plausible.deriving.arbitrary true in
+/--
+trace: [plausible.deriving.arbitrary] ⏎
+    [mutual
+       def instArbitraryValue.arbitrary : Nat → Plausible.Gen (@Value✝) :=
+         let rec aux_arb (fuel✝ : Nat) : Plausible.Gen (@Value✝) :=
+           (match fuel✝ with
+           | Nat.zero =>
+             Plausible.Gen.oneOfWithDefault (pure Value.none)
+               [(pure Value.none),
+                 (do
+                   let a✝ ← Plausible.Arbitrary.arbitrary
+                   return Value.bool a✝),
+                 (do
+                   let a✝¹ ← Plausible.Arbitrary.arbitrary
+                   return Value.int a✝¹),
+                 (do
+                   let a✝² ← Plausible.Arbitrary.arbitrary
+                   return Value.string a✝²),
+                 (pure Value.ellipsis),
+                 (do
+                   let a✝³ ← Plausible.Arbitrary.arbitrary
+                   let a✝⁴ ← Plausible.Arbitrary.arbitrary
+                   return Value.tensor a✝³ a✝⁴)]
+           | fuel'✝ + 1 =>
+             Plausible.Gen.frequency (pure Value.none)
+               [(1, (pure Value.none)),
+                 (1,
+                   (do
+                     let a✝ ← Plausible.Arbitrary.arbitrary
+                     return Value.bool a✝)),
+                 (1,
+                   (do
+                     let a✝¹ ← Plausible.Arbitrary.arbitrary
+                     return Value.int a✝¹)),
+                 (1,
+                   (do
+                     let a✝² ← Plausible.Arbitrary.arbitrary
+                     return Value.string a✝²)),
+                 (1, (pure Value.ellipsis)),
+                 (1,
+                   (do
+                     let a✝³ ← Plausible.Arbitrary.arbitrary
+                     let a✝⁴ ← Plausible.Arbitrary.arbitrary
+                     return Value.tensor a✝³ a✝⁴)),
+                 ])
+         fun fuel✝ => aux_arb fuel✝
+     end,
+     instance : Plausible.ArbitraryFueled✝ (@Value✝) :=
+       ⟨instArbitraryValue.arbitrary⟩]
+-/
+#guard_msgs in
+deriving instance Arbitrary for Value
+
+-- Test that we can successfully synthesize instances of `Arbitrary` & `ArbitraryFueled`
+
+/-- info: instArbitraryFueledValue -/
+#guard_msgs in
+#synth ArbitraryFueled Value
+
+/-- info: instArbitraryOfArbitraryFueled -/
+#guard_msgs in
+#synth Arbitrary Value
+
+/-- `Shrinkable` instance for `Value`s which recursively
+    shrinks each argument to a constructor -/
+instance : Shrinkable Value where
+  shrink (v : Value) :=
+    match v with
+    | .none | .ellipsis => []
+    | .bool b => .bool <$> Shrinkable.shrink b
+    | .int n => .int <$> Shrinkable.shrink n
+    | .string s => .string <$> Shrinkable.shrink s
+    | .tensor shape dtype =>
+      let shrunkenShapes := Shrinkable.shrink shape
+      let shrunkenDtypes := Shrinkable.shrink dtype
+      (Function.uncurry .tensor) <$> List.zip shrunkenShapes shrunkenDtypes
+
+/-- `SampleableExt` instance for `Value` -/
+instance : SampleableExt Value :=
+  SampleableExt.mkSelfContained Arbitrary.arbitrary
+
+-- To test whether the derived generator can generate counterexamples,
+-- we state an (erroneous) property that states that all `Value`s are `Bool`s
+-- and see if the generator can refute this property.
+
+/-- Determines whether a `Value` is a `Bool` -/
+def isBool (v : Value) : Bool :=
+  match v with
+  | .bool _ => true
+  | _ => false
+
+/-- error: Found a counter-example! -/
+#guard_msgs in
+#eval Testable.check (∀ v : Value, isBool v)
+  (cfg := {numInst := 10, maxSize := 5, quiet := true})

--- a/Test/DeriveArbitrary/DeriveRegExpGenerator.lean
+++ b/Test/DeriveArbitrary/DeriveRegExpGenerator.lean
@@ -1,0 +1,121 @@
+import Plausible.Attr
+import Plausible.Arbitrary
+import Plausible.DeriveArbitrary
+import Plausible.Testable
+
+open Plausible Gen
+
+set_option guard_msgs.diff true
+
+/-- An inductive datatype representing regular expressions (where "characters" are `Nat`s).
+   Adapted from the Inductive Propositions chapter of Software Foundations, volume 1:
+   See https://softwarefoundations.cis.upenn.edu/lf-current/IndProp.html
+   and search for "Case Study: Regular Expressions".
+   The `RegExp`s below are non-polymorphic in the character type. -/
+inductive RegExp : Type where
+  | EmptySet : RegExp
+  | EmptyStr : RegExp
+  | Char : Nat → RegExp -- using Nat instead of Char
+  | App : RegExp → RegExp → RegExp
+  | Union : RegExp → RegExp → RegExp
+  | Star : RegExp → RegExp
+  deriving Repr, BEq
+
+set_option trace.plausible.deriving.arbitrary true in
+/--
+trace: [plausible.deriving.arbitrary] ⏎
+    [mutual
+       def instArbitraryRegExp.arbitrary : Nat → Plausible.Gen (@RegExp✝) :=
+         let rec aux_arb (fuel✝ : Nat) : Plausible.Gen (@RegExp✝) :=
+           (match fuel✝ with
+           | Nat.zero =>
+             Plausible.Gen.oneOfWithDefault (pure RegExp.EmptySet)
+               [(pure RegExp.EmptySet), (pure RegExp.EmptyStr),
+                 (do
+                   let a✝ ← Plausible.Arbitrary.arbitrary
+                   return RegExp.Char a✝)]
+           | fuel'✝ + 1 =>
+             Plausible.Gen.frequency (pure RegExp.EmptySet)
+               [(1, (pure RegExp.EmptySet)), (1, (pure RegExp.EmptyStr)),
+                 (1,
+                   (do
+                     let a✝ ← Plausible.Arbitrary.arbitrary
+                     return RegExp.Char a✝)),
+                 (fuel'✝ + 1,
+                   (do
+                     let a✝¹ ← aux_arb fuel'✝
+                     let a✝² ← aux_arb fuel'✝
+                     return RegExp.App a✝¹ a✝²)),
+                 (fuel'✝ + 1,
+                   (do
+                     let a✝³ ← aux_arb fuel'✝
+                     let a✝⁴ ← aux_arb fuel'✝
+                     return RegExp.Union a✝³ a✝⁴)),
+                 (fuel'✝ + 1,
+                   (do
+                     let a✝⁵ ← aux_arb fuel'✝
+                     return RegExp.Star a✝⁵))])
+         fun fuel✝ => aux_arb fuel✝
+     end,
+     instance : Plausible.ArbitraryFueled✝ (@RegExp✝) :=
+       ⟨instArbitraryRegExp.arbitrary⟩]
+-/
+#guard_msgs in
+deriving instance Arbitrary for RegExp
+
+-- Test that we can successfully synthesize instances of `Arbitrary` & `ArbitraryFueled`
+
+/-- info: instArbitraryFueledRegExp -/
+#guard_msgs in
+#synth ArbitraryFueled RegExp
+
+/-- info: instArbitraryOfArbitraryFueled -/
+#guard_msgs in
+#synth Arbitrary RegExp
+
+/-!
+Test that we can use the derived generator to find counterexamples.
+
+We construct a faulty property, which (erroneously) states that
+all regular expressions never accept any string. (Example taken from
+UPenn CIS 5520 https://www.seas.upenn.edu/~cis5520/current/hw/hw04/RegExp.html)
+
+```lean
+∀ r : RegExp, neverMatchesAnyString r == True
+```
+
+(This property is faulty, since there exist regular expressions, e.g. `EmptyString`
+which do match some string!)
+
+We then test that the derived generator for `Tree`s succesfully
+generates a counterexample (e.g. `EmptyString`) which refutes the property.
+-/
+
+/-- Determines whether a regular expression *never* matches any string -/
+def neverMatchesAnyString (r : RegExp) : Bool :=
+  match r with
+  | .EmptySet => true
+  | .EmptyStr | .Char _ | .Star _ => false       -- Note that `Star` can always match the empty string
+  | .App r1 r2 => neverMatchesAnyString r1 || neverMatchesAnyString r2
+  | .Union r1 r2 => neverMatchesAnyString r1 && neverMatchesAnyString r2
+
+/-- A shrinker for regular expressions -/
+def shrinkRegExp (r : RegExp) : List RegExp :=
+  match r with
+  | .EmptySet | .EmptyStr => []
+  | .Char _ => [.EmptyStr]
+  | .Star r' => .Star <$> shrinkRegExp r'
+  | .App r1 r2 | .Union r1 r2 => shrinkRegExp r1 ++ shrinkRegExp r2
+
+/-- `Shrinkable` instance for `RegExp` -/
+instance : Shrinkable RegExp where
+  shrink := shrinkRegExp
+
+/-- `SampleableExt` instance for `RegExp` -/
+instance : SampleableExt RegExp :=
+  SampleableExt.mkSelfContained Arbitrary.arbitrary
+
+/-- error: Found a counter-example! -/
+#guard_msgs in
+#eval Testable.check (∀ r : RegExp, neverMatchesAnyString r == True)
+  (cfg := {numInst := 10, maxSize := 5, quiet := true})

--- a/Test/DeriveArbitrary/DeriveSTLCTermTypeGenerators.lean
+++ b/Test/DeriveArbitrary/DeriveSTLCTermTypeGenerators.lean
@@ -1,0 +1,181 @@
+import Plausible.Arbitrary
+import Plausible.DeriveArbitrary
+import Plausible.Attr
+import Plausible.Testable
+
+open Plausible Gen
+
+set_option guard_msgs.diff true
+
+/-- Base types in the Simply-Typed Lambda Calculus (STLC)
+    (either Nat or functions) -/
+inductive type where
+  | Nat : type
+  | Fun : type → type → type
+  deriving BEq, DecidableEq, Repr
+
+/-- Terms in the STLC extended with naturals and addition -/
+inductive term where
+  | Const: Nat → term
+  | Add: term → term → term
+  | Var: Nat → term
+  | App: term → term → term
+  | Abs: type → term → term
+  deriving BEq, Repr
+
+-- Invoke deriving instance handler for the `Arbitrary` typeclass on `type` and `term`
+set_option trace.plausible.deriving.arbitrary true in
+/--
+trace: [plausible.deriving.arbitrary] ⏎
+    [mutual
+       def instArbitraryType.arbitrary : Nat → Plausible.Gen (@type✝) :=
+         let rec aux_arb (fuel✝ : Nat) : Plausible.Gen (@type✝) :=
+           (match fuel✝ with
+           | Nat.zero => Plausible.Gen.oneOfWithDefault (pure type.Nat) [(pure type.Nat)]
+           | fuel'✝ + 1 =>
+             Plausible.Gen.frequency (pure type.Nat)
+               [(1, (pure type.Nat)),
+                 (fuel'✝ + 1,
+                   (do
+                     let a✝ ← aux_arb fuel'✝
+                     let a✝¹ ← aux_arb fuel'✝
+                     return type.Fun a✝ a✝¹))])
+         fun fuel✝ => aux_arb fuel✝
+     end,
+     instance : Plausible.ArbitraryFueled✝ (@type✝) :=
+       ⟨instArbitraryType.arbitrary⟩]
+---
+trace: [plausible.deriving.arbitrary] ⏎
+    [mutual
+       def instArbitraryTerm.arbitrary : Nat → Plausible.Gen (@term✝) :=
+         let rec aux_arb (fuel✝ : Nat) : Plausible.Gen (@term✝) :=
+           (match fuel✝ with
+           | Nat.zero =>
+             Plausible.Gen.oneOfWithDefault
+               (do
+                 let a✝ ← Plausible.Arbitrary.arbitrary
+                 return term.Const a✝)
+               [(do
+                   let a✝ ← Plausible.Arbitrary.arbitrary
+                   return term.Const a✝),
+                 (do
+                   let a✝¹ ← Plausible.Arbitrary.arbitrary
+                   return term.Var a✝¹)]
+           | fuel'✝ + 1 =>
+             Plausible.Gen.frequency
+               (do
+                 let a✝ ← Plausible.Arbitrary.arbitrary
+                 return term.Const a✝)
+               [(1,
+                   (do
+                     let a✝ ← Plausible.Arbitrary.arbitrary
+                     return term.Const a✝)),
+                 (1,
+                   (do
+                     let a✝¹ ← Plausible.Arbitrary.arbitrary
+                     return term.Var a✝¹)),
+                 (fuel'✝ + 1,
+                   (do
+                     let a✝² ← aux_arb fuel'✝
+                     let a✝³ ← aux_arb fuel'✝
+                     return term.Add a✝² a✝³)),
+                 (fuel'✝ + 1,
+                   (do
+                     let a✝⁴ ← aux_arb fuel'✝
+                     let a✝⁵ ← aux_arb fuel'✝
+                     return term.App a✝⁴ a✝⁵)),
+                 (fuel'✝ + 1,
+                   (do
+                     let a✝⁶ ← Plausible.Arbitrary.arbitrary
+                     let a✝⁷ ← aux_arb fuel'✝
+                     return term.Abs a✝⁶ a✝⁷))])
+         fun fuel✝ => aux_arb fuel✝
+     end,
+     instance : Plausible.ArbitraryFueled✝ (@term✝) :=
+       ⟨instArbitraryTerm.arbitrary⟩]
+-/
+#guard_msgs in
+deriving instance Arbitrary for type, term
+
+-- Test that we can successfully synthesize instances of `Arbitrary` & `ArbitraryFueled`
+-- for both `type` & `term`
+
+/-- info: instArbitraryFueledType -/
+#guard_msgs in
+#synth ArbitraryFueled type
+
+/-- info: instArbitraryFueledTerm -/
+#guard_msgs in
+#synth ArbitraryFueled term
+
+/-- info: instArbitraryOfArbitraryFueled -/
+#guard_msgs in
+#synth Arbitrary type
+
+/-- info: instArbitraryOfArbitraryFueled -/
+#guard_msgs in
+#synth Arbitrary term
+
+
+/-!
+Test that we can use the derived generator to find counterexamples.
+
+We construct two faulty properties:
+1. `∀ (term : term), isValue term = true`
+2. `∀ (ty : type), isFunctionType ty = true`
+
+Both of these properties are false, since there exist terms in the STLC
+which are not values (e.g. function applications), and there are
+types which are not function types (e.g. `Nat`).
+
+We then test that the respective derived generators for `term`s and `type`s
+generate counterexamples which refute the aforementioned properties.
+-/
+
+/-- Determines whether a `term` is a value.
+    (Note that only constant `Nat`s and lambda abstractions are considered values in the STLC.) -/
+def isValue (tm : term) : Bool :=
+  match tm with
+  | .Const _ | .Abs _ _ => true
+  | _ => false
+
+/-- Determines whether a `type` is a function type -/
+def isFunctionType (ty : type) : Bool :=
+  match ty with
+  | .Nat => false
+  | .Fun _ _ => true
+
+/-- `Shrinkable` instance for `type` -/
+instance : Shrinkable type where
+  shrink (ty : type) :=
+    match ty with
+    | .Nat => []
+    | .Fun t1 t2 => [.Nat, t1, t2]
+
+/-- `Shrinkable` instance for `term` -/
+instance : Shrinkable term where
+  shrink := shrinkTerm
+    where
+      shrinkTerm (tm : term) : List term :=
+        match tm with
+        | .Const _ | .Var _ => []
+        | .App e1 e2 | .Add e1 e2 => shrinkTerm e1 ++ shrinkTerm e2
+        | .Abs _ e => shrinkTerm e
+
+/-- `SampleableExt` instance for `type` -/
+instance : SampleableExt type :=
+  SampleableExt.mkSelfContained Arbitrary.arbitrary
+
+/-- `SampleableExt` instance for `term` -/
+instance : SampleableExt term :=
+   SampleableExt.mkSelfContained Arbitrary.arbitrary
+
+/-- error: Found a counter-example! -/
+#guard_msgs in
+#eval Testable.check (∀ (term : term), isValue term)
+  (cfg := {numInst := 10, maxSize := 5, quiet := true})
+
+/-- error: Found a counter-example! -/
+#guard_msgs in
+#eval Testable.check (∀ (ty : type), isFunctionType ty)
+  (cfg := {numInst := 10, maxSize := 5, quiet := true})

--- a/Test/DeriveArbitrary/DeriveTreeGenerator.lean
+++ b/Test/DeriveArbitrary/DeriveTreeGenerator.lean
@@ -1,0 +1,111 @@
+import Plausible.Attr
+import Plausible.Arbitrary
+import Plausible.DeriveArbitrary
+import Plausible.Testable
+
+open Plausible Gen
+
+set_option guard_msgs.diff true
+
+/-- A binary tree is either a single `Leaf`,
+    or a `Node` containing a `Nat` with left & right sub-trees -/
+inductive Tree where
+| Leaf : Tree
+| Node : Nat → Tree → Tree → Tree
+deriving BEq, Repr
+
+-- Invoke deriving instance handler for the `Arbitrary` typeclass on `type` and `term`
+set_option trace.plausible.deriving.arbitrary true in
+/--
+trace: [plausible.deriving.arbitrary] ⏎
+    [mutual
+       def instArbitraryTree.arbitrary : Nat → Plausible.Gen (@Tree✝) :=
+         let rec aux_arb (fuel✝ : Nat) : Plausible.Gen (@Tree✝) :=
+           (match fuel✝ with
+           | Nat.zero => Plausible.Gen.oneOfWithDefault (pure Tree.Leaf) [(pure Tree.Leaf)]
+           | fuel'✝ + 1 =>
+             Plausible.Gen.frequency (pure Tree.Leaf)
+               [(1, (pure Tree.Leaf)),
+                 (fuel'✝ + 1,
+                   (do
+                     let a✝ ← Plausible.Arbitrary.arbitrary
+                     let a✝¹ ← aux_arb fuel'✝
+                     let a✝² ← aux_arb fuel'✝
+                     return Tree.Node a✝ a✝¹ a✝²))])
+         fun fuel✝ => aux_arb fuel✝
+     end,
+     instance : Plausible.ArbitraryFueled✝ (@Tree✝) :=
+       ⟨instArbitraryTree.arbitrary⟩]
+-/
+#guard_msgs in
+deriving instance Arbitrary for Tree
+
+-- Test that we can successfully synthesize instances of `Arbitrary` & `ArbitraryFueled`
+
+/-- info: instArbitraryFueledTree -/
+#guard_msgs in
+#synth ArbitraryFueled Tree
+
+/-- info: instArbitraryOfArbitraryFueled -/
+#guard_msgs in
+#synth Arbitrary Tree
+
+
+/-!
+Test that we can use the derived generator to find counterexamples.
+
+We construct a faulty property, which (erroneously) states that
+mirroring a tree does not yield the original tree. (Example taken
+from "Generating Good Generators for Inductive Relations", POPL '18)
+
+```lean
+∀ t : Tree, mirror (mirror t) != t
+```
+
+where `mirror` is defined as follows:
+
+```lean
+def mirror (t : Tree) : Tree :=
+  match t with
+  | .Leaf => .Leaf
+  | .Node x l r => .Node x r l
+```
+
+(This property is faulty, since `mirror` is an involution.)
+
+We then test that the derived generator for `Tree`s succesfully
+generates a counterexample (e.g. `Leaf`) which refutes the property.
+-/
+
+/-- Mirrors a tree, i.e. interchanges the left & right children of all `Node`s -/
+def mirror (t : Tree) : Tree :=
+  match t with
+  | .Leaf => .Leaf
+  | .Node x l r => .Node x r l
+
+/-- A shrinker for `Tree`, adapted from Penn CIS 5520 lecture notes
+    https://www.seas.upenn.edu/~cis5520/current/lectures/stub/05-quickcheck/QuickCheck.html -/
+def shrinkTree (t : Tree) : List Tree :=
+    match t with
+    | .Leaf => [] -- empty trees can't be shrunk
+    | .Node x l r =>
+      [.Leaf, l, r]                                         -- left and right trees are smaller
+      ++ (fun l' => .Node x l' r) <$> shrinkTree l          -- shrink left subtree
+      ++ (fun r' => .Node x l r') <$> shrinkTree r          -- shrink right tree
+      ++ (fun x' => .Node x' l r) <$> Shrinkable.shrink x   -- shrink the value
+
+/-- `Shrinkable` instance for `Tree` -/
+instance : Shrinkable Tree where
+  shrink := shrinkTree
+
+/-- `SampleableExt` instance for `Tree` -/
+instance : SampleableExt Tree :=
+  SampleableExt.mkSelfContained Arbitrary.arbitrary
+
+-- Mirroring a tree twice should yield the original tree
+-- Test that we can succesfully generate a counterexample to the erroneous property
+
+/-- error: Found a counter-example! -/
+#guard_msgs in
+#eval Testable.check (∀ t : Tree, mirror (mirror t) != t)
+  (cfg := {numInst := 10, maxSize := 5, quiet := true})

--- a/Test/DeriveArbitrary/MissingNonRecursiveConstructorTest.lean
+++ b/Test/DeriveArbitrary/MissingNonRecursiveConstructorTest.lean
@@ -1,0 +1,21 @@
+import Plausible.Arbitrary
+import Plausible.DeriveArbitrary
+import Plausible.Attr
+
+open Plausible
+
+/-- A variant of a binary tree datatype where the
+    non-recursive `Leaf` constructor is missing.
+
+    We are unable to derive a generator for this type,
+    since it is impossible to construct an inhabitant of this type.
+
+    The test below checks that an appropriate error message is emitted
+    by the deriving handler. -/
+inductive TreeNoLeaf where
+  | Node : Nat → TreeNoLeaf → TreeNoLeaf → TreeNoLeaf
+
+set_option trace.plausible.deriving.arbitrary true in
+/-- error: derive Arbitrary failed, TreeNoLeaf has no non-recursive constructors -/
+#guard_msgs in
+deriving instance Arbitrary for TreeNoLeaf

--- a/Test/DeriveArbitrary/MutuallyRecursiveTypeTest.lean
+++ b/Test/DeriveArbitrary/MutuallyRecursiveTypeTest.lean
@@ -1,0 +1,173 @@
+import Plausible.Arbitrary
+import Plausible.DeriveArbitrary
+import Plausible.Attr
+import Plausible.Testable
+
+open Plausible
+
+/-
+# Testing the deriving `Arbitrary` handler on mutually recursive inductive types
+
+To test that our derived generators can handle mutually recursive types,
+we define two mutually recursive types (one `inductive` and one `structure`)
+to represent a binary tree.
+
+(Example adapted from Cornell CS 3110 lecture notes
+https://www.cs.cornell.edu/courses/cs3110/2008fa/lectures/lec04.html)
+
+```lean
+mutual
+  inductive NatTree
+    | Empty : NatTree
+    | Node : Node → NatTree
+    deriving Nonempty
+
+  structure Node where
+    value : Nat
+    left : NatTree
+    right : NatTree
+    deriving Nonempty
+end
+```
+
+Note that the user needs to add the `deriving Nonempty` annotation
+to each type in the mutually recursive definition -- this is needed
+in order to convince Lean that the type `Nat → Plausible.Gen NatTree`
+is empty during the derivation process.
+
+-/
+
+mutual
+  /-- A (possibly empty) binary tree -/
+  inductive NatTree
+    | Empty : NatTree
+    | Node : Node → NatTree
+    deriving Nonempty, Repr
+
+  /-- A child node in a tree, containing a value and two subtrees -/
+  structure Node where
+    value : Nat
+    left : NatTree
+    right : NatTree
+    deriving Nonempty
+end
+
+
+set_option trace.plausible.deriving.arbitrary true in
+/--
+trace: [plausible.deriving.arbitrary] ⏎
+    [mutual
+       partial def instArbitraryNatTree.arbitrary_1 : Nat → Plausible.Gen (@NatTree✝) :=
+         let localinst✝ : Plausible.ArbitraryFueled✝ (@NatTree✝) := ⟨instArbitraryNatTree.arbitrary_1⟩;
+         let localinst✝¹ : Plausible.ArbitraryFueled✝ (@Node✝) := ⟨instArbitraryNatTree.arbitrary_2⟩;
+         let rec aux_arb (fuel✝ : Nat) : Plausible.Gen (@NatTree✝) :=
+           (match fuel✝ with
+           | Nat.zero =>
+             Plausible.Gen.oneOfWithDefault (pure NatTree.Empty)
+               [(pure NatTree.Empty),
+                 (do
+                   let a✝ ← Plausible.Arbitrary.arbitrary
+                   return NatTree.Node a✝)]
+           | fuel'✝ + 1 =>
+             Plausible.Gen.frequency (pure NatTree.Empty)
+               [(1, (pure NatTree.Empty)),
+                 (1,
+                   (do
+                     let a✝ ← Plausible.Arbitrary.arbitrary
+                     return NatTree.Node a✝)),
+                 ])
+         fun fuel✝ => aux_arb fuel✝
+       partial def instArbitraryNatTree.arbitrary_2 : Nat → Plausible.Gen (@Node✝) :=
+         let localinst✝² : Plausible.ArbitraryFueled✝ (@NatTree✝) := ⟨instArbitraryNatTree.arbitrary_1⟩;
+         let localinst✝³ : Plausible.ArbitraryFueled✝ (@Node✝) := ⟨instArbitraryNatTree.arbitrary_2⟩;
+         let rec aux_arb (fuel✝¹ : Nat) : Plausible.Gen (@Node✝) :=
+           (match fuel✝¹ with
+           | Nat.zero =>
+             Plausible.Gen.oneOfWithDefault
+               (do
+                 let a✝¹ ← Plausible.Arbitrary.arbitrary
+                 let a✝² ← Plausible.Arbitrary.arbitrary
+                 let a✝³ ← Plausible.Arbitrary.arbitrary
+                 return Node.mk a✝¹ a✝² a✝³)
+               [(do
+                   let a✝¹ ← Plausible.Arbitrary.arbitrary
+                   let a✝² ← Plausible.Arbitrary.arbitrary
+                   let a✝³ ← Plausible.Arbitrary.arbitrary
+                   return Node.mk a✝¹ a✝² a✝³)]
+           | fuel'✝¹ + 1 =>
+             Plausible.Gen.frequency
+               (do
+                 let a✝¹ ← Plausible.Arbitrary.arbitrary
+                 let a✝² ← Plausible.Arbitrary.arbitrary
+                 let a✝³ ← Plausible.Arbitrary.arbitrary
+                 return Node.mk a✝¹ a✝² a✝³)
+               [(1,
+                   (do
+                     let a✝¹ ← Plausible.Arbitrary.arbitrary
+                     let a✝² ← Plausible.Arbitrary.arbitrary
+                     let a✝³ ← Plausible.Arbitrary.arbitrary
+                     return Node.mk a✝¹ a✝² a✝³)),
+                 ])
+         fun fuel✝¹ => aux_arb fuel✝¹
+     end,
+     instance : Plausible.ArbitraryFueled✝ (@NatTree✝) :=
+       ⟨instArbitraryNatTree.arbitrary_1⟩]
+-/
+#guard_msgs in
+deriving instance Arbitrary for NatTree
+
+-- Test that we can successfully synthesize instances of `Arbitrary` & `ArbitraryFueled`
+
+/-- info: instArbitraryFueledNatTree -/
+#guard_msgs in
+#synth ArbitraryFueled NatTree
+
+/-- info: instArbitraryOfArbitraryFueled -/
+#guard_msgs in
+#synth Arbitrary NatTree
+
+/-- `search tree x` recursively searches for a value `x` in `tree`,
+    returning a `Bool` indicating `x`'s membership in `tree`
+
+    (Note that `tree` may not obey the binary search tree
+    invariant, so this algorithm is not the most efficient.) -/
+def search (tree : NatTree) (x : Nat) : Bool :=
+  match tree with
+  | .Empty => false
+  | .Node { value, left, right } =>
+    value == x || search left x || search right x
+
+/-- A shrinker for `NatTree`, adapted from Penn CIS 5520 lecture notes
+    https://www.seas.upenn.edu/~cis5520/current/lectures/stub/05-quickcheck/QuickCheck.html -/
+def shrinkNatTree (tree : NatTree) : List NatTree :=
+    match tree with
+    | .Empty => []
+    | .Node {value := x, left := l, right := r} =>
+      [.Empty, l, r]                                                            -- left and right trees are smaller
+      ++ (fun l' => NatTree.Node $ Node.mk x l' r) <$> shrinkNatTree l          -- shrink left subtree
+      ++ (fun r' => NatTree.Node $ Node.mk x l r') <$> shrinkNatTree r          -- shrink right tree
+      ++ (fun x' => NatTree.Node $ Node.mk x' l r) <$> Shrinkable.shrink x      -- shrink the value
+
+/-- `Shrinkable` instance for `NatTree` -/
+instance : Shrinkable NatTree where
+  shrink := shrinkNatTree
+
+/-- `SampleableExt` instance for `NatTree` -/
+instance : SampleableExt NatTree :=
+  SampleableExt.mkSelfContained Arbitrary.arbitrary
+
+
+/-!
+To test whether the derived generator can generate counterexamples,
+we create an erroneous property `∀ tree : NatTree, search tree 5`,
+and ask Plausible to falsify it.
+
+(This property is false, since there exist trees which don't contain the value 5,
+e.g. the `Empty` tree.)
+
+-/
+
+/-- error: Found a counter-example! -/
+#guard_msgs in
+#eval Testable.check (∀ tree : NatTree, search tree 5)
+  (cfg := {numInst := 10, maxSize := 2, quiet := true})

--- a/Test/DeriveArbitrary/ParameterizedTypeTest.lean
+++ b/Test/DeriveArbitrary/ParameterizedTypeTest.lean
@@ -1,0 +1,106 @@
+import Plausible.Arbitrary
+import Plausible.DeriveArbitrary
+import Plausible.Attr
+import Plausible.Testable
+
+open Plausible
+
+/-- A dummy `inductive` type isomorphic to the polymorphic `List` type,
+    used as an example of a parameterized inductive type -/
+inductive MyList (α : Type) where
+  | MyNil : MyList α
+  | MyCons : α → MyList α → MyList α
+  deriving Repr, BEq
+
+set_option trace.plausible.deriving.arbitrary true in
+/--
+trace: [plausible.deriving.arbitrary] ⏎
+    [mutual
+       def instArbitraryMyList.arbitrary {α✝} [Plausible.Arbitrary✝ α✝] : Nat → Plausible.Gen (@MyList✝ α✝) :=
+         let rec aux_arb (fuel✝ : Nat) : Plausible.Gen (@MyList✝ α✝) :=
+           (match fuel✝ with
+           | Nat.zero => Plausible.Gen.oneOfWithDefault (pure MyList.MyNil) [(pure MyList.MyNil)]
+           | fuel'✝ + 1 =>
+             Plausible.Gen.frequency (pure MyList.MyNil)
+               [(1, (pure MyList.MyNil)),
+                 (fuel'✝ + 1,
+                   (do
+                     let a✝ ← Plausible.Arbitrary.arbitrary
+                     let a✝¹ ← aux_arb fuel'✝
+                     return MyList.MyCons a✝ a✝¹))])
+         fun fuel✝ => aux_arb fuel✝
+     end,
+     instance {α✝} [Plausible.Arbitrary✝ α✝] : Plausible.ArbitraryFueled✝ (@MyList✝ α✝) :=
+       ⟨instArbitraryMyList.arbitrary⟩]
+-/
+#guard_msgs in
+deriving instance Arbitrary for MyList
+
+-- Test that we can successfully synthesize instances of `Arbitrary` & `ArbitraryFueled`
+-- when `α` is specialized to `Nat`
+
+/-- info: instArbitraryFueledMyListOfArbitrary -/
+#guard_msgs in
+#synth ArbitraryFueled (MyList Nat)
+
+/-- info: instArbitraryOfArbitraryFueled -/
+#guard_msgs in
+#synth Arbitrary (MyList Nat)
+
+-- Infrastructure for testing the derived generator
+
+/-- Converts a `MyList` to an ordinary `List` -/
+def listOfMyList (l : MyList α) : List α :=
+  match l with
+  | .MyNil => []
+  | .MyCons x xs => x :: listOfMyList xs
+
+/-- Converts an ordinary `List` to a `MyList` -/
+def myListOfList (l : List α) : MyList α :=
+  match l with
+  | [] => .MyNil
+  | x :: xs => .MyCons x (myListOfList xs)
+
+/-- Trivial shrinker for `MyList α`.
+    (Under the hood, this converts the `MyList` to an ordinary `List`,
+    uses the default `Shrinkable` instance for `List α`, then converts it back to `MyList α`.) -/
+def shrinkMyList [Shrinkable α] (myList : MyList α) : List (MyList α) :=
+  let l := listOfMyList myList
+  myListOfList <$> Shrinkable.shrink l
+
+/-- `Shrinkable` instance for `MyList α` -/
+instance [Shrinkable α] : Shrinkable (MyList α) where
+  shrink := shrinkMyList
+
+/- `SampleableExt` instance for `MyList α`.
+
+   (Note that the proxy type is still `MyList α` in this instance, and not `List α`,
+   since we are creating the `SampleableExt` instance using `SampleableExt.mkSelfContained`.) -/
+instance [Repr α] [Shrinkable α] [Arbitrary α] : SampleableExt (MyList α) :=
+  SampleableExt.mkSelfContained Arbitrary.arbitrary
+
+/-!
+To test whether the derived generator can generate counterexamples,
+we create an erroneous property `∀ l : MyList Nat, reverse (reverse l) != l`,
+and ask Plausible to falsify it.
+
+(This property is false, since `reverse` is an involution on `List α`, and
+`MyList α` is isomorphic to `List α`.)
+-/
+
+/-- Returns the elements of a `MyList α` in reverse order.
+
+    Implementation adapted from the Haskell `List.reverse` function.
+    https://hackage.haskell.org/package/base-4.17.1.0/docs/Prelude.html#v:reverse -/
+def reverse (l : MyList α) : MyList α :=
+  rev l .MyNil
+    where
+      rev (l : MyList α) (acc : MyList α) :=
+        match l with
+        | .MyNil => acc
+        | .MyCons x xs => rev xs (.MyCons x acc)
+
+/-- error: Found a counter-example! -/
+#guard_msgs in
+#eval Testable.check (∀ l : MyList Nat, reverse (reverse l) != l)
+  (cfg := {numInst := 10, maxSize := 5, quiet := true})

--- a/Test/DeriveArbitrary/StructureTest.lean
+++ b/Test/DeriveArbitrary/StructureTest.lean
@@ -1,0 +1,108 @@
+import Plausible.Arbitrary
+import Plausible.DeriveArbitrary
+import Plausible.Attr
+import Plausible.Testable
+
+open Plausible Gen
+
+set_option guard_msgs.diff true
+
+/-!
+
+To test whether the derived generator can handle `structure`s with named fields,
+we define a dummy `structure`:
+
+```lean
+structure Foo where
+  stringField : String
+  boolField : Bool
+  natField : Nat
+```
+
+To test whether the derived generator finds counterexamples,
+we create a faulty property:
+
+```lean
+∀ foo : Foo, foo.stringField.isEmpty || !foo.boolField || foo.natField == 0)
+```
+
+The derived generator should be able to generate inhabitants of `Foo`
+where `stringField` is non-empty, where `boolField` is false
+and `natField` is non-zero.
+
+-/
+
+/-- Dummy `structure` with named fields -/
+structure Foo where
+  stringField : String
+  boolField : Bool
+  natField : Nat
+  deriving Repr
+
+-- Test that we can successfully synthesize instances of `Arbitrary` & `ArbitraryFueled`
+set_option trace.plausible.deriving.arbitrary true in
+/--
+trace: [plausible.deriving.arbitrary] ⏎
+    [mutual
+       def instArbitraryFoo.arbitrary : Nat → Plausible.Gen (@Foo✝) :=
+         let rec aux_arb (fuel✝ : Nat) : Plausible.Gen (@Foo✝) :=
+           (match fuel✝ with
+           | Nat.zero =>
+             Plausible.Gen.oneOfWithDefault
+               (do
+                 let a✝ ← Plausible.Arbitrary.arbitrary
+                 let a✝¹ ← Plausible.Arbitrary.arbitrary
+                 let a✝² ← Plausible.Arbitrary.arbitrary
+                 return Foo.mk a✝ a✝¹ a✝²)
+               [(do
+                   let a✝ ← Plausible.Arbitrary.arbitrary
+                   let a✝¹ ← Plausible.Arbitrary.arbitrary
+                   let a✝² ← Plausible.Arbitrary.arbitrary
+                   return Foo.mk a✝ a✝¹ a✝²)]
+           | fuel'✝ + 1 =>
+             Plausible.Gen.frequency
+               (do
+                 let a✝ ← Plausible.Arbitrary.arbitrary
+                 let a✝¹ ← Plausible.Arbitrary.arbitrary
+                 let a✝² ← Plausible.Arbitrary.arbitrary
+                 return Foo.mk a✝ a✝¹ a✝²)
+               [(1,
+                   (do
+                     let a✝ ← Plausible.Arbitrary.arbitrary
+                     let a✝¹ ← Plausible.Arbitrary.arbitrary
+                     let a✝² ← Plausible.Arbitrary.arbitrary
+                     return Foo.mk a✝ a✝¹ a✝²)),
+                 ])
+         fun fuel✝ => aux_arb fuel✝
+     end,
+     instance : Plausible.ArbitraryFueled✝ (@Foo✝) :=
+       ⟨instArbitraryFoo.arbitrary⟩]
+-/
+#guard_msgs in
+deriving instance Arbitrary for Foo
+
+/-- info: instArbitraryFueledFoo -/
+#guard_msgs in
+#synth ArbitraryFueled Foo
+
+/-- info: instArbitraryOfArbitraryFueled -/
+#guard_msgs in
+#synth Arbitrary Foo
+
+/-- `Shrinkable` instance for `Foo`, which shrinks each of its constituent fields -/
+instance : Shrinkable Foo where
+  shrink (foo : Foo) :=
+    let strings := Shrinkable.shrink foo.stringField
+    let bools := Shrinkable.shrink foo.boolField
+    let nats := Shrinkable.shrink foo.natField
+    let zippedFields := List.zip (List.zip strings bools) nats
+    (fun ((s, b), n) => Foo.mk s b n) <$> zippedFields
+
+/-- `SampleableExt` instance for `Tree` -/
+instance : SampleableExt Foo :=
+  SampleableExt.mkSelfContained Arbitrary.arbitrary
+
+/-- error: Found a counter-example! -/
+#guard_msgs in
+#eval Testable.check (∀ foo : Foo, foo.stringField.isEmpty || !foo.boolField || foo.natField == 0)
+  (cfg := {numInst := 100, maxSize := 5, quiet := true})


### PR DESCRIPTION
WIP: this is a re-do of PR #35, mostly unchanged but for breaking the `ArbitraryFuled` class out.

I'm actually now convinced that we might want a fueled class in addition to `size`: e.g. for tree-like structures, the number of nodes is exponential in the depth at the moment. Is this the behavior we want? If so, then we want to keep size small but perhaps allow fuel to be large. If we switch `size` to correspond to the number of nodes, then now fuel has to be huge if we generate many things.

For now though, we should always be generating total functions, so fuel should be relatively moot. I can try to remove it if we feel that it is a distraction.