### PR TITLE
Fix docs typo (syntax for optional arguments)

### DIFF
--- a/Plausible/Tactic.lean
+++ b/Plausible/Tactic.lean
@@ -141,7 +141,7 @@ admit. If it gives up or finds a counter-example, it reports an error.
 For more information on writing your own `Sampleable` and `Testable`
 instances, see `Testing.Plausible.Testable`.
 
-Optional arguments given with `plausible (config : { ... })`
+Optional arguments given with `plausible (config := { ... })`
 * `numInst` (default 100): number of examples to test properties with
 * `maxSize` (default 100): final size argument
 


### PR DESCRIPTION
The documentation for the tactic currently suggests something like this:
```lean
example (x y : Nat) : x = y := by
  plausible (config : {maxSize := 200})
```
When it clearly should be:
```lean
example (x y : Nat) : x = y := by
  plausible (config := {maxSize := 200})
```