### PR TITLE
Deriving Handler for `Shrinkable`

### DIFF
--- a/Plausible.lean
+++ b/Plausible.lean
@@ -14,3 +14,4 @@ public import Plausible.Attr
 public import Plausible.Tactic
 public import Plausible.Arbitrary
 public import Plausible.DeriveArbitrary
+public import Plausible.DeriveShrinkable

--- a/Plausible/DeriveArbitrary.lean
+++ b/Plausible/DeriveArbitrary.lean
@@ -82,8 +82,8 @@ def getCtorArgsNamesAndTypes (_header : Header) (indVal : InductiveVal) (ctorNam
   forallTelescopeReducing ctorInfo.type fun args _ => do
     let mut argNamesAndTypes := #[]
 
-    for i in *...args.size do
-      let arg := args[i]!
+    for h : i in 0...args.size do
+      let arg := args[i]
       let argType ← arg.fvarId!.getType
 
       if i < indVal.numParams then
@@ -123,7 +123,7 @@ open TSyntax.Compat in
     since it expects the inst-implicit binders and the instance we're creating to both belong to the same typeclass. -/
 def mkArbitraryFueledInstanceCmds (ctx : Deriving.Context) (typeNames : Array Name) (useAnonCtor := true) : TermElabM (Array Command) := do
   let mut instances := #[]
-  for i in [:ctx.typeInfos.size] do
+  for i in 0...ctx.typeInfos.size do
     let indVal       := ctx.typeInfos[i]!
     if typeNames.contains indVal.name then
       let auxFunName   := ctx.auxFunNames[i]!
@@ -205,7 +205,7 @@ def mkBody (header : Header) (inductiveVal : InductiveVal) (generatorType : TSyn
             -- produce a recursive call to the generator using `aux_arb`,
             -- otherwise generate a value using `arbitrary`
             let bindExpr ←
-              if argType.getAppFn.constName == targetTypeName then
+              if argType.isAppOf targetTypeName then
                 -- We've detected that the constructor has a recursive argument, so we update the flag
                 ctorIsRecursive := true
                 `(doElem| let $freshIdent ← $(mkIdent `aux_arb):term $(freshFuel'):term)
@@ -290,7 +290,7 @@ def mkAuxFunction (ctx : Deriving.Context) (i : Nat) : TermElabM Command := do
 /-- Creates a `mutual ... end` block containing the definitions of the derived generators -/
 def mkMutualBlock (ctx : Deriving.Context) : TermElabM Syntax := do
   let mut auxDefs := #[]
-  for i in *...ctx.typeInfos.size do
+  for i in 0...ctx.typeInfos.size do
     auxDefs := auxDefs.push (← mkAuxFunction ctx i)
   `(mutual
      $auxDefs:command*
@@ -306,14 +306,16 @@ private def mkArbitraryFueledInstanceCmd (declName : Name) : TermElabM (Array Sy
 /-- Deriving handler which produces an instance of the `ArbitraryFueled` typeclass for
     each type specified in `declNames` -/
 def mkArbitraryInstanceHandler (declNames : Array Name) : CommandElabM Bool := do
-  if (← declNames.allM isInductive) then
-    for declName in declNames do
-      let cmds ← liftTermElabM $ mkArbitraryFueledInstanceCmd declName
-      cmds.forM elabCommand
-    return true
-  else
+  if !(← declNames.allM isInductive) then
     throwError "Cannot derive instance of Arbitrary typeclass for non-inductive types"
-    return false
+  for declName in declNames do
+    let indVal ← liftTermElabM $ getConstInfoInduct declName
+    if indVal.numIndices > 0 then
+      throwError "Cannot derive instance of Arbitrary typeclass for indexed inductive type '{declName}'"
+  for declName in declNames do
+    let cmds ← liftTermElabM $ mkArbitraryFueledInstanceCmd declName
+    cmds.forM elabCommand
+  return true
 
 initialize
   registerDerivingHandler ``Arbitrary mkArbitraryInstanceHandler

--- a/Plausible/DeriveShrinkable.lean
+++ b/Plausible/DeriveShrinkable.lean
@@ -1,0 +1,208 @@
+/-
+Copyright (c) 2025. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+import Lean
+import Lean.Elab.Deriving.Basic
+import Lean.Elab.Deriving.Util
+
+import Plausible.Sampleable
+
+open Lean Elab Meta Parser Term
+open Elab.Deriving
+open Elab.Command
+
+/-!
+# Deriving Handler for `Shrinkable`
+
+This file defines a handler which automatically derives `Shrinkable` instances
+for inductive types.
+
+The derived shrinker for a value `C x₁ ... xₙ` produces:
+1. **Subterm shrinks**: any `xᵢ` whose type equals the inductive type itself
+   (these are strictly smaller subterms).
+2. **Argument shrinks**: for each `xᵢ`, shrink it via its `Shrinkable` instance
+   and reconstruct the constructor with the shrunk value, holding all other
+   arguments fixed.
+
+Example usage:
+```lean
+inductive Tree where
+  | Leaf : Tree
+  | Node : Nat → Tree → Tree → Tree
+  deriving Shrinkable
+```
+
+To view the derived code, enable the trace class:
+```lean
+set_option trace.plausible.deriving.shrinkable true
+```
+-/
+
+initialize registerTraceClass `plausible.deriving.shrinkable
+
+namespace Plausible
+
+open Shrinkable
+
+/-! ## Helpers (adapted from Plausible.DeriveArbitrary) -/
+
+/-- Returns `(argument_name, argument_type)` pairs for a constructor,
+    skipping the inductive's type parameters. Freshens names to avoid macro scopes. -/
+private def getCtorArgsNamesAndTypes (indVal : InductiveVal) (ctorName : Name) :
+    MetaM (Array (Name × Expr)) := do
+  let ctorInfo ← getConstInfoCtor ctorName
+  forallTelescopeReducing ctorInfo.type fun args _ => do
+    let mut result := #[]
+    for i in [:args.size] do
+      if i < indVal.numParams then continue
+      let arg := args[i]!
+      let argType ← arg.fvarId!.getType
+      let argName ← Core.mkFreshUserName `a
+      result := result.push (argName, argType)
+    return result
+
+open TSyntax.Compat in
+/-- Builds a `Header` with only implicit + instance binders (no explicit target binder).
+    Adapted from `Plausible.mkHeaderWithOnlyImplicitBinders`. -/
+private def mkShrinkableHeader (indVal : InductiveVal) : TermElabM Header := do
+  let argNames ← mkInductArgNames indVal
+  let binders ← mkImplicitBinders argNames
+  let targetType ← mkInductiveApp indVal argNames
+  let binders := binders ++ (← mkInstImplicitBinders ``Plausible.Shrinkable indVal argNames)
+  return { binders, argNames, targetNames := #[], targetType }
+
+/-! ## Core shrink-expression builder -/
+
+/-- For constructor `C x₁ ... xₙ` of inductive type `T`, builds the `List T` expression:
+    - subterm shrinks: each `xᵢ : T` is yielded directly
+    - argument shrinks: for each `xᵢ`, shrink it and reconstruct `C` with the shrunk value
+    For recursive fields (type = T), uses `auxFn` for the recursive call instead of
+    `Shrinkable.shrink`, since the instance doesn't exist yet during derivation. -/
+private def mkCtorShrinkExpr (targetTypeName : Name) (ctorIdent : Ident)
+    (freshIdents : Array Ident) (argTypes : Array Expr)
+    (auxFn : Ident) : TermElabM Term := do
+  let mut listTerms : Array Term := #[]
+
+  -- 1) Subterm shrinks: yield recursive fields directly
+  for i in [:freshIdents.size] do
+    if argTypes[i]!.getAppFn.constName == targetTypeName then
+      listTerms := listTerms.push (← `([$(freshIdents[i]!)]))
+
+  -- 2) Argument shrinks: shrink each field and reconstruct
+  for i in [:freshIdents.size] do
+    let xi := freshIdents[i]!
+    let xi' := mkIdent (← Core.mkFreshUserName `x')
+    let mut reconstructArgs : Array Term := #[]
+    for j in [:freshIdents.size] do
+      if i == j then
+        reconstructArgs := reconstructArgs.push (← `($xi'))
+      else
+        reconstructArgs := reconstructArgs.push (← `($(freshIdents[j]!)))
+    let mapBody ← `(fun $xi' => $ctorIdent $reconstructArgs*)
+    -- Use recursive call for self-referential fields, Shrinkable.shrink for others
+    let shrinkCall ←
+      if argTypes[i]!.getAppFn.constName == targetTypeName then
+        `($auxFn $xi)
+      else
+        `(Shrinkable.shrink $xi)
+    let shrinkExpr ← `(($shrinkCall).map $mapBody)
+    listTerms := listTerms.push shrinkExpr
+
+  match listTerms.toList with
+  | [] => `(([] : List _))
+  | [single] => pure single
+  | first :: rest =>
+    rest.foldlM (fun acc t => `($acc ++ $t)) first
+
+/-! ## Auxiliary function and instance generation -/
+
+/-- Creates the auxiliary shrink function definition for one inductive type. -/
+private def mkAuxFunction (ctx : Deriving.Context) (i : Nat) : TermElabM Command := do
+  let auxFunName := ctx.auxFunNames[i]!
+  let indVal := ctx.typeInfos[i]!
+  let header ← mkShrinkableHeader indVal
+
+  let targetType ← mkInductiveApp indVal header.argNames
+  let retType ← `(List $targetType)
+  let x := mkIdent (← Core.mkFreshUserName `x)
+  let auxFn := mkIdent auxFunName
+
+  let mut matchAlts : TSyntaxArray ``Term.matchAlt := #[]
+
+  for ctorName in indVal.ctors do
+    let ctorIdent := mkIdent ctorName
+    let ctorArgNamesTypes ← getCtorArgsNamesAndTypes indVal ctorName
+    let argTypes := ctorArgNamesTypes.map Prod.snd
+    let freshIdents := (ctorArgNamesTypes.map Prod.fst).map Lean.mkIdent
+
+    let body ← mkCtorShrinkExpr indVal.name ctorIdent freshIdents argTypes auxFn
+
+    if freshIdents.isEmpty then
+      matchAlts := matchAlts.push (← `(Term.matchAltExpr| | $ctorIdent => $body))
+    else
+      matchAlts := matchAlts.push (← `(Term.matchAltExpr| | $ctorIdent $freshIdents* => $body))
+
+  let matchExpr ← `(match $x:ident with $matchAlts:matchAlt*)
+  let mut body ← `(fun ($x : $targetType) => $matchExpr)
+
+  if ctx.usePartial then
+    let letDecls ← mkLocalInstanceLetDecls ctx ``Plausible.Shrinkable header.argNames
+    body ← mkLet letDecls body
+
+  let binders := header.binders
+  let fullType ← `($targetType → $retType)
+  if ctx.usePartial then
+    `(partial def $auxFn:ident $binders:bracketedBinder* : $fullType := $body)
+  else
+    `(def $auxFn:ident $binders:bracketedBinder* : $fullType := $body)
+
+/-- Creates a `mutual ... end` block containing the shrink function definitions -/
+private def mkMutualBlock (ctx : Deriving.Context) : TermElabM Syntax := do
+  let mut auxDefs := #[]
+  for i in [:ctx.typeInfos.size] do
+    auxDefs := auxDefs.push (← mkAuxFunction ctx i)
+  `(mutual $auxDefs:command* end)
+
+open TSyntax.Compat in
+/-- Creates instance commands for the `Shrinkable` typeclass -/
+private def mkShrinkableInstanceCmds (ctx : Deriving.Context) (typeNames : Array Name) :
+    TermElabM (Array Command) := do
+  let mut instances := #[]
+  for i in [:ctx.typeInfos.size] do
+    let indVal := ctx.typeInfos[i]!
+    if typeNames.contains indVal.name then
+      let auxFunName := ctx.auxFunNames[i]!
+      let argNames ← mkInductArgNames indVal
+      let binders ← mkImplicitBinders argNames
+      let binders := binders ++ (← mkInstImplicitBinders ``Plausible.Shrinkable indVal argNames)
+      let indType ← mkInductiveApp indVal argNames
+      let type ← `(Shrinkable $indType)
+      let instCmd ← `(instance $binders:implicitBinder* : $type := ⟨$(mkIdent auxFunName)⟩)
+      instances := instances.push instCmd
+  return instances
+
+/-- Derives a `Shrinkable` instance for a single inductive type -/
+private def mkShrinkableInstanceCmd (declName : Name) : TermElabM (Array Syntax) := do
+  let ctx ← mkContext ``Plausible.Shrinkable "shrink" declName
+  let cmds := #[← mkMutualBlock ctx] ++ (← mkShrinkableInstanceCmds ctx #[declName])
+  trace[plausible.deriving.shrinkable] "\n{cmds}"
+  return cmds
+
+/-- Deriving handler for `Shrinkable` -/
+def mkShrinkableInstanceHandler (declNames : Array Name) : CommandElabM Bool := do
+  if (← declNames.allM isInductive) then
+    for declName in declNames do
+      let cmds ← liftTermElabM $ mkShrinkableInstanceCmd declName
+      cmds.forM elabCommand
+    return true
+  else
+    throwError "Cannot derive instance of Shrinkable typeclass for non-inductive types"
+    return false
+
+initialize
+  registerDerivingHandler ``Shrinkable mkShrinkableInstanceHandler
+
+end Plausible

--- a/Plausible/DeriveShrinkable.lean
+++ b/Plausible/DeriveShrinkable.lean
@@ -1,10 +1,10 @@
 /-
-Copyright (c) 2025. All rights reserved.
+Copyright (c) 2025 AWS. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: AWS
 -/
 module
 
-import Lean
 import Lean.Elab.Deriving.Basic
 import Lean.Elab.Deriving.Util
 
@@ -56,9 +56,9 @@ private def getCtorArgsNamesAndTypes (indVal : InductiveVal) (ctorName : Name) :
   let ctorInfo ← getConstInfoCtor ctorName
   forallTelescopeReducing ctorInfo.type fun args _ => do
     let mut result := #[]
-    for i in [:args.size] do
+    for h : i in 0...args.size do
       if i < indVal.numParams then continue
-      let arg := args[i]!
+      let arg := args[i]
       let argType ← arg.fvarId!.getType
       let argName ← Core.mkFreshUserName `a
       result := result.push (argName, argType)
@@ -87,24 +87,24 @@ private def mkCtorShrinkExpr (targetTypeName : Name) (ctorIdent : Ident)
   let mut listTerms : Array Term := #[]
 
   -- 1) Subterm shrinks: yield recursive fields directly
-  for i in [:freshIdents.size] do
-    if argTypes[i]!.getAppFn.constName == targetTypeName then
-      listTerms := listTerms.push (← `([$(freshIdents[i]!)]))
+  for h : i in 0...freshIdents.size do
+    if argTypes[i]!.isAppOf targetTypeName then
+      listTerms := listTerms.push (← `([$(freshIdents[i])]))
 
   -- 2) Argument shrinks: shrink each field and reconstruct
-  for i in [:freshIdents.size] do
-    let xi := freshIdents[i]!
+  for h : i in 0...freshIdents.size do
+    let xi := freshIdents[i]
     let xi' := mkIdent (← Core.mkFreshUserName `x')
     let mut reconstructArgs : Array Term := #[]
-    for j in [:freshIdents.size] do
+    for h' : j in 0...freshIdents.size do
       if i == j then
         reconstructArgs := reconstructArgs.push (← `($xi'))
       else
-        reconstructArgs := reconstructArgs.push (← `($(freshIdents[j]!)))
+        reconstructArgs := reconstructArgs.push (← `($(freshIdents[j])))
     let mapBody ← `(fun $xi' => $ctorIdent $reconstructArgs*)
     -- Use recursive call for self-referential fields, Shrinkable.shrink for others
     let shrinkCall ←
-      if argTypes[i]!.getAppFn.constName == targetTypeName then
+      if argTypes[i]!.isAppOf targetTypeName then
         `($auxFn $xi)
       else
         `(Shrinkable.shrink $xi)
@@ -112,7 +112,7 @@ private def mkCtorShrinkExpr (targetTypeName : Name) (ctorIdent : Ident)
     listTerms := listTerms.push shrinkExpr
 
   match listTerms.toList with
-  | [] => `(([] : List _))
+  | [] => `([])
   | [single] => pure single
   | first :: rest =>
     rest.foldlM (fun acc t => `($acc ++ $t)) first
@@ -162,7 +162,7 @@ private def mkAuxFunction (ctx : Deriving.Context) (i : Nat) : TermElabM Command
 /-- Creates a `mutual ... end` block containing the shrink function definitions -/
 private def mkMutualBlock (ctx : Deriving.Context) : TermElabM Syntax := do
   let mut auxDefs := #[]
-  for i in [:ctx.typeInfos.size] do
+  for i in 0...ctx.typeInfos.size do
     auxDefs := auxDefs.push (← mkAuxFunction ctx i)
   `(mutual $auxDefs:command* end)
 
@@ -171,7 +171,7 @@ open TSyntax.Compat in
 private def mkShrinkableInstanceCmds (ctx : Deriving.Context) (typeNames : Array Name) :
     TermElabM (Array Command) := do
   let mut instances := #[]
-  for i in [:ctx.typeInfos.size] do
+  for i in 0...ctx.typeInfos.size do
     let indVal := ctx.typeInfos[i]!
     if typeNames.contains indVal.name then
       let auxFunName := ctx.auxFunNames[i]!
@@ -193,14 +193,16 @@ private def mkShrinkableInstanceCmd (declName : Name) : TermElabM (Array Syntax)
 
 /-- Deriving handler for `Shrinkable` -/
 def mkShrinkableInstanceHandler (declNames : Array Name) : CommandElabM Bool := do
-  if (← declNames.allM isInductive) then
-    for declName in declNames do
-      let cmds ← liftTermElabM $ mkShrinkableInstanceCmd declName
-      cmds.forM elabCommand
-    return true
-  else
+  if !(← declNames.allM isInductive) then
     throwError "Cannot derive instance of Shrinkable typeclass for non-inductive types"
-    return false
+  for declName in declNames do
+    let indVal ← liftTermElabM $ getConstInfoInduct declName
+    if indVal.numIndices > 0 then
+      throwError "Cannot derive instance of Shrinkable typeclass for indexed inductive type '{declName}'"
+  for declName in declNames do
+    let cmds ← liftTermElabM $ mkShrinkableInstanceCmd declName
+    cmds.forM elabCommand
+  return true
 
 initialize
   registerDerivingHandler ``Shrinkable mkShrinkableInstanceHandler

--- a/PlausibleTest.lean
+++ b/PlausibleTest.lean
@@ -17,3 +17,7 @@ import PlausibleTest.DeriveArbitrary.BitVecStructureTest
 import PlausibleTest.DeriveArbitrary.MissingNonRecursiveConstructorTest
 import PlausibleTest.DeriveArbitrary.ParameterizedTypeTest
 import PlausibleTest.DeriveArbitrary.MutuallyRecursiveTypeTest
+
+-- Tests for `deriving Shrinkable`
+import PlausibleTest.DeriveShrinkable.DeriveShrinkableTest
+import PlausibleTest.DeriveShrinkable.DeriveShrinkableMutualTest

--- a/PlausibleTest/DeriveArbitrary/ParameterizedTypeTest.lean
+++ b/PlausibleTest/DeriveArbitrary/ParameterizedTypeTest.lean
@@ -36,6 +36,16 @@ trace: [plausible.deriving.arbitrary] ⏎
 #guard_msgs in
 deriving instance Arbitrary for MyList
 
+-- Test that we reject attempts to derive `Arbitrary` on indexed types
+
+inductive Vec : Nat → Type where
+  | nil : Vec 0
+  | cons (x : Nat) (xs : Vec n) : Vec (n + 1)
+
+/-- error: Cannot derive instance of Arbitrary typeclass for indexed inductive type 'Vec' -/
+#guard_msgs in
+deriving instance Arbitrary for Vec
+
 -- Test that we can successfully synthesize instances of `Arbitrary` & `ArbitraryFueled`
 -- when `α` is specialized to `Nat`
 

--- a/PlausibleTest/DeriveShrinkable/DeriveShrinkableMutualTest.lean
+++ b/PlausibleTest/DeriveShrinkable/DeriveShrinkableMutualTest.lean
@@ -1,0 +1,49 @@
+import Plausible
+
+open Plausible
+
+namespace ShrinkableMutualTests
+
+-- Mutually recursive types
+mutual
+  inductive Even where
+    | zero : Even
+    | succOdd : Odd → Even
+
+  inductive Odd where
+    | succEven : Even → Odd
+end
+
+deriving instance Repr, Shrinkable for Even, Odd
+
+-- `deriving instance ... for` on a non-mutual recursive type
+inductive Expr where
+  | Lit : Nat → Expr
+  | Add : Expr → Expr → Expr
+  | Neg : Expr → Expr
+  deriving Repr
+
+deriving instance Shrinkable for Expr
+
+/-- info: [] -/
+#guard_msgs in
+#eval Shrinkable.shrink (Even.succOdd (Odd.succEven Even.zero))
+
+/--
+info: [ShrinkableMutualTests.Expr.Lit 3,
+ ShrinkableMutualTests.Expr.Neg (ShrinkableMutualTests.Expr.Lit 1),
+ ShrinkableMutualTests.Expr.Add
+   (ShrinkableMutualTests.Expr.Lit 1)
+   (ShrinkableMutualTests.Expr.Neg (ShrinkableMutualTests.Expr.Lit 1)),
+ ShrinkableMutualTests.Expr.Add
+   (ShrinkableMutualTests.Expr.Lit 0)
+   (ShrinkableMutualTests.Expr.Neg (ShrinkableMutualTests.Expr.Lit 1)),
+ ShrinkableMutualTests.Expr.Add (ShrinkableMutualTests.Expr.Lit 3) (ShrinkableMutualTests.Expr.Lit 1),
+ ShrinkableMutualTests.Expr.Add
+   (ShrinkableMutualTests.Expr.Lit 3)
+   (ShrinkableMutualTests.Expr.Neg (ShrinkableMutualTests.Expr.Lit 0))]
+-/
+#guard_msgs in
+#eval Shrinkable.shrink (Expr.Add (Expr.Lit 3) (Expr.Neg (Expr.Lit 1)))
+
+end ShrinkableMutualTests

--- a/PlausibleTest/DeriveShrinkable/DeriveShrinkableTest.lean
+++ b/PlausibleTest/DeriveShrinkable/DeriveShrinkableTest.lean
@@ -1,0 +1,76 @@
+import Plausible
+
+open Plausible
+
+namespace ShrinkableTests
+
+-- Simple enum type
+inductive Color where
+  | Red | Green | Blue
+  deriving Repr, Shrinkable
+
+-- Binary tree (recursive, with non-recursive field)
+inductive Tree where
+  | Leaf : Tree
+  | Node : Nat → Tree → Tree → Tree
+  deriving Repr, Shrinkable
+
+-- Parameterized type
+inductive ShrinkList (α : Type) where
+  | Nil : ShrinkList α
+  | Cons : α → ShrinkList α → ShrinkList α
+  deriving Repr, Shrinkable
+
+-- Structure (single-constructor inductive)
+structure Point where
+  x : Nat
+  y : Nat
+  deriving Repr, Shrinkable
+
+-- Nullary constructors shrink to []
+/-- info: [] -/
+#guard_msgs in
+#eval Shrinkable.shrink Color.Red
+
+/-- info: [] -/
+#guard_msgs in
+#eval Shrinkable.shrink Tree.Leaf
+
+-- Shrinking a Node yields subterms (Leaf, Leaf) + argument shrinks (shrinking the Nat)
+/--
+info: [ShrinkableTests.Tree.Leaf,
+ ShrinkableTests.Tree.Leaf,
+ ShrinkableTests.Tree.Node 2 (ShrinkableTests.Tree.Leaf) (ShrinkableTests.Tree.Leaf),
+ ShrinkableTests.Tree.Node 1 (ShrinkableTests.Tree.Leaf) (ShrinkableTests.Tree.Leaf),
+ ShrinkableTests.Tree.Node 0 (ShrinkableTests.Tree.Leaf) (ShrinkableTests.Tree.Leaf)]
+-/
+#guard_msgs in
+#eval Shrinkable.shrink (Tree.Node 5 Tree.Leaf Tree.Leaf)
+
+-- Shrinking a parameterized list
+/--
+info: [ShrinkableTests.ShrinkList.Cons 1 (ShrinkableTests.ShrinkList.Nil),
+ ShrinkableTests.ShrinkList.Cons 1 (ShrinkableTests.ShrinkList.Cons 1 (ShrinkableTests.ShrinkList.Nil)),
+ ShrinkableTests.ShrinkList.Cons 0 (ShrinkableTests.ShrinkList.Cons 1 (ShrinkableTests.ShrinkList.Nil)),
+ ShrinkableTests.ShrinkList.Cons 3 (ShrinkableTests.ShrinkList.Nil),
+ ShrinkableTests.ShrinkList.Cons 3 (ShrinkableTests.ShrinkList.Cons 0 (ShrinkableTests.ShrinkList.Nil))]
+-/
+#guard_msgs in
+#eval Shrinkable.shrink (ShrinkList.Cons 3 (ShrinkList.Cons 1 ShrinkList.Nil))
+
+-- Shrinking a structure
+/--
+info: [{ x := 5, y := 20 },
+ { x := 2, y := 20 },
+ { x := 1, y := 20 },
+ { x := 0, y := 20 },
+ { x := 10, y := 10 },
+ { x := 10, y := 5 },
+ { x := 10, y := 2 },
+ { x := 10, y := 1 },
+ { x := 10, y := 0 }]
+-/
+#guard_msgs in
+#eval Shrinkable.shrink (Point.mk 10 20)
+
+end ShrinkableTests

--- a/PlausibleTest/DeriveShrinkable/DeriveShrinkableTest.lean
+++ b/PlausibleTest/DeriveShrinkable/DeriveShrinkableTest.lean
@@ -73,4 +73,12 @@ info: [{ x := 5, y := 20 },
 #guard_msgs in
 #eval Shrinkable.shrink (Point.mk 10 20)
 
+inductive Vec : Nat → Type where
+  | nil : Vec 0
+  | cons (x : Nat) (xs : Vec n) : Vec (n + 1)
+
+/-- error: Cannot derive instance of Shrinkable typeclass for indexed inductive type 'ShrinkableTests.Vec' -/
+#guard_msgs in
+deriving instance Shrinkable for Vec
+
 end ShrinkableTests


### PR DESCRIPTION
Deriving Handler for `Shrinkable`

This file defines a handler which automatically derives `Shrinkable` instances for inductive types.

The derived shrinker for a value `C x₁ ... xₙ` produces:
1. **Subterm shrinks**: any `xᵢ` whose type equals the inductive type itself (these are strictly smaller subterms).
2. **Argument shrinks**: for each `xᵢ`, shrink it via its `Shrinkable` instance and reconstruct the constructor with the shrunk value, holding all other arguments fixed.

Several examples are given in the added tests.