### PR TITLE
feat: option to not error when failing to tackle problems

### DIFF
--- a/Plausible/Tactic.lean
+++ b/Plausible/Tactic.lean
@@ -172,7 +172,11 @@ elab_rules : tactic | `(tactic| plausible $[$cfg]?) => withMainContext do
       || (← isTracingEnabledFor `plausible.shrink.candidates) }
   let inst ← try
     synthInstance (← mkAppM ``Testable #[tgt'])
-  catch _ => throwError "\
+  catch _ =>
+    if cfg.sorryIfNoTestable then
+      admitGoal g
+      return
+    throwError "\
       Failed to create a `testable` instance for `{tgt}`.\
     \nWhat to do:\
     \n1. make sure that the types you are using have `Plausible.SampleableExt` instances\

--- a/Plausible/Testable.lean
+++ b/Plausible/Testable.lean
@@ -136,15 +136,20 @@ structure Configuration where
   Disable output.
   -/
   quiet : Bool := false
+  /--
+  If `true`, when the `Testable` instance required to begin testing cannot be synthesized,
+  silently admit the goal with `sorry` instead of throwing an error.
+  -/
+  sorryIfNoTestable : Bool := false
   deriving Inhabited
 
 open Lean in
 instance : ToExpr Configuration where
   toTypeExpr := mkConst `Configuration
-  toExpr cfg := mkApp9 (mkConst ``Configuration.mk)
+  toExpr cfg := mkApp10 (mkConst ``Configuration.mk)
     (toExpr cfg.numInst) (toExpr cfg.maxSize) (toExpr cfg.numRetries) (toExpr cfg.traceDiscarded)
     (toExpr cfg.traceSuccesses) (toExpr cfg.traceShrink) (toExpr cfg.traceShrinkCandidates)
-    (toExpr cfg.randomSeed) (toExpr cfg.quiet)
+    (toExpr cfg.randomSeed) (toExpr cfg.quiet) (toExpr cfg.sorryIfNoTestable)
 
 /--
 Allow elaboration of `Configuration` arguments to tactics.

--- a/PlausibleTest/Tactic.lean
+++ b/PlausibleTest/Tactic.lean
@@ -169,3 +169,37 @@ warning: declaration uses `sorry`
 #guard_msgs in
 theorem true_example_with_guard (a : Nat) (ha : 4 ≤ a) : a = a := by
   plausible
+
+private structure NoTestableInstance where
+  x : Nat
+
+/--
+error: Failed to create a `testable` instance for `∀ (a : NoTestableInstance), a.x = 0`.
+What to do:
+1. make sure that the types you are using have `Plausible.SampleableExt` instances
+ (you can use `#sample my_type` if you are unsure);
+2. make sure that the relations and predicates that your proposition use are decidable;
+3. if your hypothesis is big consider increasing `set_option synthInstance.maxSize` to a
+    ⏎
+  higher power of two
+    ⏎
+4. make sure that instances of `Plausible.Testable` exist that, when combined,
+  apply to your decorated proposition:
+```
+Plausible.NamedBinder "a" (∀ (a : NoTestableInstance), a.x = 0)
+```
+
+Use `set_option trace.Meta.synthInstance true` to understand what instances are missing.
+
+Try this:
+set_option trace.Meta.synthInstance true
+#synth Plausible.Testable (Plausible.NamedBinder "a" (∀ (a : NoTestableInstance), a.x = 0))
+-/
+#guard_msgs in
+example (a : NoTestableInstance) : a.x = 0 := by
+  plausible
+
+/-- warning: declaration uses `sorry` -/
+#guard_msgs in
+example (a : NoTestableInstance) : a.x = 0 := by
+  plausible (config := { sorryIfNoTestable := true })


### PR DESCRIPTION
This PR allows plausible to be invoked using ` plausible (config := { sorryIfNoTestable := true })`. This option ensures that if plausible fails to even begin testing the goal, it will silently put a `sorry` instead of erroring out. This can be useful for just using `plausible` instead of `sorry` in a project to ensure that there are no trivially false theorems.