### PR TITLE
chore: reduce imports

### DIFF
--- a/Plausible/Arbitrary.lean
+++ b/Plausible/Arbitrary.lean
@@ -5,7 +5,7 @@ Authors: AWS
 -/
 module
 
-public meta import Plausible.Gen
+public import Plausible.Gen
 
 public meta section
 

--- a/Plausible/ArbitraryFueled.lean
+++ b/Plausible/ArbitraryFueled.lean
@@ -6,7 +6,6 @@ Authors: AWS
 module
 
 public import Plausible.Arbitrary
-public import Plausible.Gen
 
 public section
 

--- a/Plausible/Attr.lean
+++ b/Plausible/Attr.lean
@@ -5,7 +5,7 @@ Authors: Simon Hudon, Kim Morrison
 -/
 module
 
-public meta import Lean.Util.Trace
+meta import Lean.Util.Trace
 
 public meta section
 

--- a/Plausible/DeriveArbitrary.lean
+++ b/Plausible/DeriveArbitrary.lean
@@ -5,11 +5,9 @@ Authors: Ernest Ng
 -/
 module
 
-import Lean.Elab
 import Lean.Elab.Deriving.Basic
 import Lean.Elab.Deriving.Util
 
-import Plausible.Arbitrary
 import Plausible.ArbitraryFueled
 
 open Lean Elab Meta Parser Term

--- a/Plausible/DeriveShrinkable.lean
+++ b/Plausible/DeriveShrinkable.lean
@@ -8,7 +8,7 @@ module
 import Lean.Elab.Deriving.Basic
 import Lean.Elab.Deriving.Util
 
-import Plausible.Sampleable
+import Plausible.Shrinkable
 
 open Lean Elab Meta Parser Term
 open Elab.Deriving

--- a/Plausible/Functions.lean
+++ b/Plausible/Functions.lean
@@ -6,7 +6,6 @@ Authors: Simon Hudon
 module
 
 public meta import Plausible.Sampleable
-public meta import Plausible.Testable
 
 @[expose] public meta section
 

--- a/Plausible/Gen.lean
+++ b/Plausible/Gen.lean
@@ -5,7 +5,7 @@ Authors: Henrik Böving, Simon Hudon
 -/
 module
 
-public meta import Plausible.Random
+public import Plausible.Random
 
 public meta section
 

--- a/Plausible/Random.lean
+++ b/Plausible/Random.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Henrik Böving
 -/
 module
-meta import Init.Data.Random
 
 public meta section
 

--- a/Plausible/Sampleable.lean
+++ b/Plausible/Sampleable.lean
@@ -7,9 +7,7 @@ module
 
 public meta import Lean.Elab.Command
 public meta import Lean.Meta.Eval
-public meta import Plausible.Gen
 public meta import Plausible.Arbitrary
-public import Plausible.Shrinkable
 public meta import Plausible.Shrinkable
 
 public meta section

--- a/Plausible/Tactic.lean
+++ b/Plausible/Tactic.lean
@@ -6,7 +6,6 @@ Authors: Simon Hudon, Kim Morrison
 module
 
 public meta import Plausible.Testable
-public meta import Plausible.Attr
 
 public meta section
 


### PR DESCRIPTION
This PR reduces imports. In particular the `import Lean.Elab` is a large import that this PR aims to remove from mathlib's imports.

At first, I used `lake shake`. I then fiddled with what I got until I was happy with the result.

An adaptation branch is not needed, because the file in mathlib that imports `Plausible` also already imports `Lean`. The  plan is to remove that in the future.