### PR TITLE
chore: reduce the use of `meta`

### DIFF
--- a/Plausible/Arbitrary.lean
+++ b/Plausible/Arbitrary.lean
@@ -7,7 +7,7 @@ module
 
 public import Plausible.Gen
 
-public meta section
+public section
 
 
 /-!

--- a/Plausible/ArbitraryFueled.lean
+++ b/Plausible/ArbitraryFueled.lean
@@ -25,7 +25,7 @@ class ArbitraryFueled (α : Type) where
   arbitraryFueled : Nat → Gen α
 
 /-- Every `ArbitraryFueled` instance gives rise to an `Arbitrary` instance -/
-meta instance [ArbitraryFueled α] : Arbitrary α where
+instance [ArbitraryFueled α] : Arbitrary α where
   arbitrary := Gen.sized ArbitraryFueled.arbitraryFueled
 
 end Plausible

--- a/Plausible/Gen.lean
+++ b/Plausible/Gen.lean
@@ -7,7 +7,7 @@ module
 
 public import Plausible.Random
 
-public meta section
+public section
 
 /-!
 # `Gen` Monad
@@ -138,7 +138,7 @@ The code for these combinators closely mirrors those used in Rocq/Coq QuickChick
 -/
 
 /-- Raised when a fueled generator fails due to insufficient fuel. -/
-meta def outOfFuel : GenError :=
+def outOfFuel : GenError :=
   .genError "out of fuel"
 
 /-- `pick default xs n` chooses a weight & a generator `(k, gen)` from the list `xs` such that `n < k`.

--- a/Plausible/Random.lean
+++ b/Plausible/Random.lean
@@ -5,7 +5,7 @@ Authors: Henrik Böving
 -/
 module
 
-public meta section
+public section
 
 /-!
 # Rand Monad and Random Class

--- a/Plausible/Sampleable.lean
+++ b/Plausible/Sampleable.lean
@@ -7,10 +7,10 @@ module
 
 public meta import Lean.Elab.Command
 public meta import Lean.Meta.Eval
-public meta import Plausible.Arbitrary
-public meta import Plausible.Shrinkable
+public import Plausible.Arbitrary
+public import Plausible.Shrinkable
 
-public meta section
+public section
 
 /-!
 # `SampleableExt` Class
@@ -232,7 +232,7 @@ directly. For this return:
 - a `Repr α` instance
 - a `Gen α` generator to run in order to sample
 -/
-private def mkGenerator (e : Expr) : MetaM (Level × Expr × Expr × Expr) := do
+private meta def mkGenerator (e : Expr) : MetaM (Level × Expr × Expr × Expr) := do
   let exprTyp ← inferType e
   let .sort u ← whnf (← inferType exprTyp) | throwError m!"{exprTyp} is not a type"
   let .succ u := u | throwError m!"{exprTyp} is not a type with computational content"

--- a/Plausible/Testable.lean
+++ b/Plausible/Testable.lean
@@ -6,9 +6,12 @@ Authors: Henrik Böving, Simon Hudon
 module
 
 public meta import Lean.Elab.Tactic.Config
-public meta import Plausible.Sampleable
+public import Lean.CoreM
+public import Lean.Exception
+public import Lean.Log
+public import Plausible.Sampleable
 
-public meta section
+public section
 
 
 /-!
@@ -143,6 +146,8 @@ structure Configuration where
   sorryIfNoTestable : Bool := false
   deriving Inhabited
 
+meta section
+
 open Lean in
 instance : ToExpr Configuration where
   toTypeExpr := mkConst `Configuration
@@ -155,6 +160,8 @@ instance : ToExpr Configuration where
 Allow elaboration of `Configuration` arguments to tactics.
 -/
 declare_config_elab elabConfig Configuration
+
+end
 
 /--
 `PrintableProp p` allows one to print a proposition so that
@@ -555,11 +562,11 @@ end IO
 
 namespace Decorations
 
-open Lean
+open Lean Elab.Tactic Meta
 
 /-- Traverse the syntax of a proposition to find universal quantifiers
 quantifiers and add `NamedBinder` annotations next to them. -/
-partial def addDecorations (e : Expr) : MetaM Expr :=
+meta partial def addDecorations (e : Expr) : MetaM Expr :=
   Meta.transform e fun expr => do
     if not (← Meta.inferType expr).isProp then
       return .done expr
@@ -576,9 +583,6 @@ partial def addDecorations (e : Expr) : MetaM Expr :=
 that the goal should be satisfied with a proposition equivalent to `p`
 with added annotations. -/
 abbrev DecorationsOf (_p : Prop) := Prop
-
-open Elab.Tactic
-open Meta
 
 /-- In a goal of the shape `⊢ DecorationsOf p`, `mk_decoration` examines
 the syntax of `p` and adds `NamedBinder` around universal quantifications


### PR DESCRIPTION
This PR minimizes the use of `meta` definitions, which makes it much easier to run Plausible properties from `main` using `checkIO` when `main` is in a module.